### PR TITLE
Fix for Issue #14: "render_METHOD" method names violate PEP8 naming conventions

### DIFF
--- a/aiocoap/resource.py
+++ b/aiocoap/resource.py
@@ -18,7 +18,7 @@ one thing as its serversite, and that is a Resource too (typically of the
 :class:`Site` class).
 
 Resources are most easily implemented by deriving from :class:`.Resource` and
-implementing ``render_GET``, ``render_POST`` and similar coroutine methods.
+implementing ``render_get``, ``render_post`` and similar coroutine methods.
 Those take a single request message object and must return a
 :class:`aiocoap.Message` object.
 
@@ -70,7 +70,7 @@ class Resource(interfaces.Resource):
     """Simple base implementation of the :class:`interfaces.Resource`
     interface
 
-    The render method delegates content creation to ``render_$METHOD`` methods,
+    The render method delegates content creation to ``render_$method`` methods,
     and responds appropriately to unsupported methods.
     """
 
@@ -82,7 +82,7 @@ class Resource(interfaces.Resource):
     def render(self, request):
         if not request.code.is_request():
             raise error.UnsupportedMethod()
-        m = getattr(self, 'render_%s' % request.code, None)
+        m = getattr(self, 'render_%s' % request.code.__str__().lower(), None)
         if not m:
             raise error.UnallowedMethod()
         return m(request)

--- a/server.py
+++ b/server.py
@@ -30,12 +30,12 @@ class BlockResource(resource.Resource):
                 "transfer.\n" + "0123456789\n" * 100).encode("ascii")
 
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         response = aiocoap.Message(code=aiocoap.CONTENT, payload=self.content)
         return response
 
     @asyncio.coroutine
-    def render_PUT(self, request):
+    def render_put(self, request):
         print('PUT payload: %s' % request.payload)
         self.content = request.payload
         payload = ("I've accepted the new payload. You may inspect it here in "\
@@ -55,7 +55,7 @@ class SeparateLargeResource(resource.Resource):
 #        self.add_param(resource.LinkParam("title", "Large resource."))
 
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         yield from asyncio.sleep(3)
 
         payload = "Three rings for the elven kings under the sky, seven rings"\
@@ -79,7 +79,7 @@ class TimeResource(resource.ObservableResource):
         asyncio.get_event_loop().call_later(60, self.notify)
 
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         payload = datetime.datetime.now().strftime("%Y-%m-%d %H:%M").encode('ascii')
         return aiocoap.Message(code=aiocoap.CONTENT, payload=payload)
 
@@ -97,7 +97,7 @@ class TimeResource(resource.ObservableResource):
 #        self.root = root
 #
 #    @asyncio.coroutine
-#    def render_GET(self, request):
+#    def render_get(self, request):
 #        data = []
 #        self.root.generate_resource_list(data, "")
 #        payload = ",".join(data).encode('utf-8')

--- a/tests/observe.py
+++ b/tests/observe.py
@@ -29,13 +29,13 @@ class ObservableCounter(ObservableResource):
         self.updated_state()
 
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         return aiocoap.Message(code=aiocoap.CONTENT, payload=str(self.count).encode('ascii'))
 
 class ObservableReplacingResource(ReplacingResource, ObservableResource):
     @asyncio.coroutine
-    def render_PUT(self, request):
-        result = yield from super(ObservableReplacingResource, self).render_PUT(request)
+    def render_put(self, request):
+        result = yield from super(ObservableReplacingResource, self).render_put(request)
 
         self.updated_state()
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -24,7 +24,7 @@ CLEANUPTIME = 0.01
 
 class MultiRepresentationResource(aiocoap.resource.Resource):
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         ct = request.opt.accept or aiocoap.numbers.media_types_rev['text/plain']
 
         if ct == aiocoap.numbers.media_types_rev['application/json']:
@@ -40,13 +40,13 @@ class MultiRepresentationResource(aiocoap.resource.Resource):
 
 class SlowResource(aiocoap.resource.Resource):
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         yield from asyncio.sleep(0.2)
         return aiocoap.Message(code=aiocoap.CONTENT)
 
 class BigResource(aiocoap.resource.Resource):
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         # 10kb
         payload = b"0123456789----------" * 512
         response = aiocoap.Message(code=aiocoap.CONTENT, payload=payload)
@@ -56,7 +56,7 @@ class BigResource(aiocoap.resource.Resource):
 
 class SlowBigResource(aiocoap.resource.Resource):
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         yield from asyncio.sleep(0.2)
         # 1.6kb
         payload = b"0123456789----------" * 80
@@ -64,16 +64,16 @@ class SlowBigResource(aiocoap.resource.Resource):
 
 class ReplacingResource(aiocoap.resource.Resource):
     @asyncio.coroutine
-    def render_GET(self, request):
+    def render_get(self, request):
         return aiocoap.Message(code=aiocoap.CONTENT, payload=self.value)
 
     @asyncio.coroutine
-    def render_PUT(self, request):
+    def render_put(self, request):
         self.value = request.payload.replace(b'0', b'O')
         return aiocoap.Message(code=aiocoap.CHANGED)
 
     @asyncio.coroutine
-    def render_POST(self, request):
+    def render_post(self, request):
         response = request.payload.replace(b'0', b'O')
         return aiocoap.Message(code=aiocoap.CONTENT, payload=response)
 


### PR DESCRIPTION
Fix for Issue #14: "render_METHOD" method names violate PEP8 naming conventions