### PR TITLE
Add install requirement for LinkHeader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
 
+    install_requires=['LinkHeader'],
+
     command_options={
         'build_sphinx': {
             'project': ('setup.py', name),


### PR DESCRIPTION
setup.py is missing the install requirement for linkheader.

```
  File "/tmp/aiocoap/aiocoap/resource.py", line 206, in get_resources_as_linkheader
    import link_header
ImportError: No module named 'link_header'
```