### PR TITLE
resource/Site: Add regular expression support for path names

### DIFF
--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ import logging
 
 import asyncio
 
+from aiocoap.resource import PathRegex
 import aiocoap.resource as resource
 import aiocoap
 
@@ -90,6 +91,15 @@ class TimeResource(resource.ObservableResource):
         payload = datetime.datetime.now().strftime("%Y-%m-%d %H:%M").encode('ascii')
         return aiocoap.Message(code=aiocoap.CONTENT, payload=payload)
 
+class RegexResource(resource.Resource):
+    """Example wildcard matching resource, use request.opt.uri_path to find the
+    actual target of the request"""
+
+    @asyncio.coroutine
+    def render_get(self, request):
+        payload = 'Regular expression match example\nrequest.opt.uri_path = {}'.format(repr(request.opt.uri_path))
+        return aiocoap.Message(code=aiocoap.CONTENT, payload=payload.encode('utf-8'))
+
 #class CoreResource(resource.Resource):
 #    """
 #    Example Resource that provides list of links hosted by a server.
@@ -128,6 +138,10 @@ def main():
     root.add_resource(('other', 'block'), BlockResource())
 
     root.add_resource(('other', 'separate'), SeparateLargeResource())
+
+    root.add_resource(('regex', 'anything', PathRegex(r'.*')), RegexResource())
+    root.add_resource(('regex', 'numbers', PathRegex(r'[0-9]*')), RegexResource())
+    root.add_resource(('regex', 'pattern', PathRegex(r'[a-zA-Z][0-9]')), RegexResource())
 
     asyncio.async(aiocoap.Context.create_server_context(root))
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -77,6 +77,12 @@ class ReplacingResource(aiocoap.resource.Resource):
         response = request.payload.replace(b'0', b'O')
         return aiocoap.Message(code=aiocoap.CONTENT, payload=response)
 
+class PathResource(aiocoap.resource.Resource):
+    @asyncio.coroutine
+    def render_get(self, request):
+        payload = repr(request.opt.uri_path).encode('utf-8')
+        return aiocoap.Message(code=aiocoap.CONTENT, payload=payload)
+
 class TestingSite(aiocoap.resource.Site):
     def __init__(self):
         super(TestingSite, self).__init__()
@@ -86,6 +92,8 @@ class TestingSite(aiocoap.resource.Site):
         self.add_resource(('big',), BigResource())
         self.add_resource(('slowbig',), SlowBigResource())
         self.add_resource(('replacing',), ReplacingResource())
+        self.add_resource(('wildcard', aiocoap.resource.PathRegex('.*')), PathResource())
+        self.add_resource(('4digits', aiocoap.resource.PathRegex('[0-9]{4}')), PathResource())
 
 # helpers
 


### PR DESCRIPTION
This PR adds an option to specify path components as regular expressions to handle dynamic sub resources without having to register each instance individually.

The example server has been updated with some new resources to demonstrate the added functionality.

Below are some example requests:

```
% ./aiocoap-client -m get 'coap://[::1]/regex/anything/blah'   
Regular expression match example
request.opt.uri_path = ('regex', 'anything', 'blah')
(No newline at end of message)
Exception ignored in: 
```

```
% ./aiocoap-client -m get 'coap://[::1]/regex/numbers/123456'
Regular expression match example
request.opt.uri_path = ('regex', 'numbers', '123456')
(No newline at end of message)
Exception ignored in: 
% ./aiocoap-client -m get 'coap://[::1]/regex/numbers/abcdef'
4.04 Not Found
Error: Resource not found!
```

```
% ./aiocoap-client -m get 'coap://[::1]/regex/pattern/a1'    
Regular expression match example
request.opt.uri_path = ('regex', 'pattern', 'a1')
(No newline at end of message)
Exception ignored in:
% ./aiocoap-client -m get 'coap://[::1]/regex/pattern/b7'
Regular expression match example
request.opt.uri_path = ('regex', 'pattern', 'b7')
(No newline at end of message)
Exception ignored in:
% ./aiocoap-client -m get 'coap://[::1]/regex/pattern/ba'
4.04 Not Found
Error: Resource not found!
```