### PR TITLE
protocol.py: Take block1.size_exponent from option if it exists

### DIFF
--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -608,7 +608,7 @@ class Request(BaseRequest, interfaces.Request):
         try:
             yield from self.protocol.fill_remote(self.app_request)
 
-            size_exp = DEFAULT_BLOCK_SIZE_EXP
+            size_exp = DEFAULT_BLOCK_SIZE_EXP if self.app_request.opt.block1 is None else self.app_request.opt.block1.size_exponent
             if len(self.app_request.payload) > (2 ** (size_exp + 4)) and self.handle_blockwise:
                 request = self.app_request._extract_block(0, size_exp)
                 self.app_request.opt.block1 = request.opt.block1


### PR DESCRIPTION
This will allow a CoAP client to set the transfer block size doing
something like: msg.opt.block1 = (0, True, 2), where 2 is the
size_exponent, which will result in 64 byte block size.

Signed-off-by: Nenad Ilic nenadilic84@gmail.com
