### PR TITLE
fix external package requirements in setup module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
 
-    extras_require={
-        'linkheader': ['LinkHeader'],
-        },
+    install_requires=[
+        'LinkHeader>=0.4.3',
+        ],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR fixes the dependency to the LinkHeader package in the `setup.py` module.
