### PR TITLE
Windows fix

### DIFF
--- a/aiocoap/transports/simple6.py
+++ b/aiocoap/transports/simple6.py
@@ -161,7 +161,7 @@ class _DatagramClientSocketpoolSimple6:
         ready = asyncio.Future()
         transport, protocol = yield from self._loop.create_datagram_endpoint(
                 lambda: _Connection(lambda: ready.set_result(None), self._new_message_callback, self._new_error_callback, sockaddr),
-                family=socket.AF_INET6,
+                #family=socket.AF_INET6,
                 flags=socket.AI_V4MAPPED,
                 remote_addr=sockaddr)
         yield from ready


### PR DESCRIPTION
This makes it possible to perform GET requests to "coap://coap.me" and "coap://[::1]" on windows
https://github.com/chrysn/aiocoap/issues/27#issuecomment-328785513