### PR TITLE
Removed socket flags for simple6 transport.

### DIFF
--- a/aiocoap/transports/simple6.py
+++ b/aiocoap/transports/simple6.py
@@ -170,8 +170,6 @@ class _DatagramClientSocketpoolSimple6:
         ready = asyncio.Future()
         transport, protocol = await self._loop.create_datagram_endpoint(
                 lambda: _Connection(lambda: ready.set_result(None), self._new_message_callback, self._new_error_callback, sockaddr),
-                family=socket.AF_INET6,
-                flags=socket.AI_V4MAPPED,
                 remote_addr=sockaddr)
         await ready
 


### PR DESCRIPTION
Removed V4MAPPED socket flag and AF_INET6 address family from socket
creation. Without any flags, this should "just work™" on all kinds of
systems, ignoring differences between V4 and V6.

As discussed in #27.