### PR TITLE
Accept BERT in BLOCK1 PUT requests

### DIFF
--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -298,8 +298,14 @@ class Message(object):
             raise ValueError("_append_request_block only works on requests.")
 
         block1 = next_block.opt.block1
-        if block1.more and len(next_block.payload) != block1.size:
-            raise error.BadRequest("Payload size does not match Block1")
+        if block1.more:
+            if len(next_block.payload) == block1.size:
+                pass
+            elif block1.size_exponent == 7 and \
+                    len(next_block.payload) % block1.size == 0:
+                pass
+            else:
+                raise error.BadRequest("Payload size does not match Block1")
         if block1.start == len(self.payload):
             self.payload += next_block.payload
             self.opt.block1 = block1


### PR DESCRIPTION
The validator for incoming BLOCK1 requests does currently require that the payload size equals the block size even if SZX=7 (BERT is used). Loosening that requirement allows to use larger payloads.

(*I relied on the guess that there is some code checking whether the use of SZX=7 is actually valid on the transport level. I did not check though.*)