### PR TITLE
blockwise: fix request block size handling

### DIFF
--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -484,7 +484,7 @@ class Context(interfaces.RequestProvider):
 
             self._block2_assemblies[block_key] = (response, canceler)
 
-            szx = request.opt.block2 if request.opt.block2 is not None \
+            szx = request.opt.block2.size_exponent if request.opt.block2 is not None \
                     else request.remote.maximum_block_size_exp
             # if a requested block2 number were not 0, the code would have
             # diverted earlier to serve from active operations


### PR DESCRIPTION
Using the server.py example, I sent a GET request for /block/other that included the block size in the request. In my test I used a block size of 32. aiocoap errored on the initial request with the traceback below. The immediate issue was the size_exp parameter sent to Message._extract_block() was a tuple rather than an integer.

The fix here changes Context._render_to_plumbing_request_inner() to send the size_exponent property from the tuple. I don't know if this the best solution, but it worked for me.

```
ERROR:coap-server:An exception occurred while rendering a resource: TypeError('can only concatenate tuple (not "int") to tuple',)
Traceback (most recent call last):
  File "/home/kbee/dev/aiocoap/repo/aiocoap/protocol.py", line 346, in _render_to_plumbing_request
    cancellation_future)
  File "/home/kbee/dev/aiocoap/repo/aiocoap/protocol.py", line 491, in _render_to_plumbing_request_inner
    response = response._extract_block(0, szx, request.remote.maximum_payload_size)
  File "/home/kbee/dev/aiocoap/repo/aiocoap/message.py", line 270, in _extract_block
    size = 2 ** (size_exp + 4)
TypeError: can only concatenate tuple (not "int") to tuple
```