### PR TITLE
tinydtls: add `-k` flag to libcoap server example to enable DTLS

### DIFF
--- a/aiocoap/transports/tinydtls.py
+++ b/aiocoap/transports/tinydtls.py
@@ -16,7 +16,7 @@ This currently only implements the client side. To have a test server, run::
     $ ./autogen.sh
     $ ./configure --with-tinydtls --disable-shared
     $ make
-    $ ./examples/coap-server
+    $ ./examples/coap-server -k secretPSK
 
 (Using TinyDTLS in libcoap is important; with the default OpenSSL build, I've
 seen DTLS1.0 responses to DTLS1.3 requests, which are hard to debug.)


### PR DESCRIPTION
libcoap will not enable DTLS support when there is no PSK passed to the server even though it is built with `--with-tinydtls` flag enabled. This PR adds the `-k` flag to the example command used to run a test libcoap server.