### PR TITLE
Fix for IN defintions that may not exist on Python 3.5

### DIFF
--- a/aiocoap/util/socknumbers.py
+++ b/aiocoap/util/socknumbers.py
@@ -20,7 +20,7 @@ would probably be including them in Python.
 
 try:
     from IN import IPV6_RECVERR, IP_RECVERR, IPV6_PKTINFO
-except ImportError:
+except (ImportError, NameError):
     IPV6_RECVERR = 25
     IP_RECVERR = 11
     IPV6_PKTINFO = 50
@@ -28,5 +28,5 @@ except ImportError:
 # for https://bitbucket.org/pypy/pypy/issues/2648/
 try:
     from socket import MSG_ERRQUEUE
-except ImportError:
+except (ImportError, NameError):
     MSG_ERRQUEUE = 8192


### PR DESCRIPTION
On some platforms (ARM 32 in my case), IN (which was a private implementation specific module that should not be used externally) may not work completely even on Python 3.5. In such cases, just treat it as absent.