### PR TITLE
Fix multicast COAP capabiltiy

### DIFF
--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -127,7 +127,7 @@ class Message(object):
         * Some options or even the payload may differ if a proxy was involved.
     """
 
-    def __init__(self, *, mtype=None, mid=None, code=None, payload=b'', token=b'', uri=None, **kwargs):
+    def __init__(self, *, mtype=None, mid=None, code=None, payload=b'', token=b'', uri=None, local=None, **kwargs):
         self.version = 1
         if mtype is None:
             # leave it unspecified for convenience, sending functions will know what to do
@@ -145,6 +145,7 @@ class Message(object):
         self.opt = Options()
 
         self.remote = None
+        self.local = local
 
         # deprecation error, should go away roughly after 0.2 release
         if self.payload is None:

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -160,7 +160,7 @@ class Context(interfaces.RequestProvider):
         self.request_interfaces.append(tman)
 
     @classmethod
-    async def create_client_context(cls, *, loggername="coap", loop=None):
+    async def create_client_context(cls, *, loggername="coap", loop=None, local=None):
         """Create a context bound to all addresses on a random listening port.
 
         This is the easiest way to get a context suitable for sending client
@@ -177,7 +177,7 @@ class Context(interfaces.RequestProvider):
             if transportname == 'udp6':
                 from .transports.udp6 import MessageInterfaceUDP6
                 await self._append_tokenmanaged_messagemanaged_transport(
-                    lambda mman: MessageInterfaceUDP6.create_client_transport_endpoint(mman, log=self.log, loop=loop))
+                    lambda mman: MessageInterfaceUDP6.create_client_transport_endpoint(mman, log=self.log, loop=loop, local=local))
             elif transportname == 'simple6':
                 from .transports.simple6 import MessageInterfaceSimple6
                 await self._append_tokenmanaged_messagemanaged_transport(
@@ -205,7 +205,7 @@ class Context(interfaces.RequestProvider):
         return self
 
     @classmethod
-    async def create_server_context(cls, site, bind=None, *, loggername="coap-server", loop=None, _ssl_context=None, multicastif=None):
+    async def create_server_context(cls, site, bind=None, *, loggername="coap-server", loop=None, _ssl_context=None, multicastif=None, local=None):
         """Create a context, bound to all addresses on the CoAP port (unless
         otherwise specified in the ``bind`` argument).
 
@@ -222,7 +222,7 @@ class Context(interfaces.RequestProvider):
                 from .transports.udp6 import MessageInterfaceUDP6
 
                 await self._append_tokenmanaged_messagemanaged_transport(
-                    lambda mman: MessageInterfaceUDP6.create_server_transport_endpoint(mman, log=self.log, loop=loop, bind=bind, multicastif=multicastif))
+                    lambda mman: MessageInterfaceUDP6.create_server_transport_endpoint(mman, log=self.log, loop=loop, bind=bind, multicastif=multicastif, local=local))
             # FIXME this is duplicated from the client version, as those are client-only anyway
             elif transportname == 'simple6':
                 from .transports.simple6 import MessageInterfaceSimple6

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -205,7 +205,7 @@ class Context(interfaces.RequestProvider):
         return self
 
     @classmethod
-    async def create_server_context(cls, site, bind=None, *, loggername="coap-server", loop=None, _ssl_context=None):
+    async def create_server_context(cls, site, bind=None, *, loggername="coap-server", loop=None, _ssl_context=None, multicastif=None):
         """Create a context, bound to all addresses on the CoAP port (unless
         otherwise specified in the ``bind`` argument).
 
@@ -222,7 +222,7 @@ class Context(interfaces.RequestProvider):
                 from .transports.udp6 import MessageInterfaceUDP6
 
                 await self._append_tokenmanaged_messagemanaged_transport(
-                    lambda mman: MessageInterfaceUDP6.create_server_transport_endpoint(mman, log=self.log, loop=loop, bind=bind))
+                    lambda mman: MessageInterfaceUDP6.create_server_transport_endpoint(mman, log=self.log, loop=loop, bind=bind, multicastif=multicastif))
             # FIXME this is duplicated from the client version, as those are client-only anyway
             elif transportname == 'simple6':
                 from .transports.simple6 import MessageInterfaceSimple6

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -101,7 +101,8 @@ class UDP6EndpointAddress(interfaces.EndpointAddress):
             return address[7:]
         return address
 
-    def _plainaddress(self):
+    @property
+    def plainaddress(self):
         """Return the IP adress part of the sockaddr in IPv4 notation if it is
         mapped, otherwise the plain v6 address including the interface
         identifier if set."""
@@ -119,7 +120,8 @@ class UDP6EndpointAddress(interfaces.EndpointAddress):
     def _decode_pktinfo(self):
         return struct.Struct("16si").unpack_from(self.pktinfo)
 
-    def _plainaddress_local(self):
+    @property
+    def plainaddress_local(self):
         """Like _plainaddress, but on the address in the pktinfo. Unlike
         _plainaddress, this does not contain the interface identifier."""
 
@@ -133,11 +135,11 @@ class UDP6EndpointAddress(interfaces.EndpointAddress):
             port = None
 
         # plainaddress: don't assume other applications can deal with v4mapped addresses
-        return hostportjoin(self._plainaddress(), port)
+        return hostportjoin(self.plainaddress, port)
 
     @property
     def hostinfo_local(self):
-        host = self._plainaddress_local()
+        host = self.plainaddress_local
         port = self.interface._local_port()
         if port == 0:
             raise ValueError("Local port read before socket has bound itself")
@@ -146,7 +148,7 @@ class UDP6EndpointAddress(interfaces.EndpointAddress):
         return hostportjoin(host, port)
 
     @property
-    def hostingo_local_ifindex(self):
+    def hostinfo_local_ifindex(self):
         addr, interface = self._decode_pktinfo()
         return interface
 
@@ -165,11 +167,11 @@ class UDP6EndpointAddress(interfaces.EndpointAddress):
 
     @property
     def is_multicast(self):
-        return ipaddress.ip_address(self._plainaddress().split('%', 1)[0]).is_multicast
+        return ipaddress.ip_address(self.plainaddress.split('%', 1)[0]).is_multicast
 
     @property
     def is_multicast_locally(self):
-        return ipaddress.ip_address(self._plainaddress_local()).is_multicast
+        return ipaddress.ip_address(self.plainaddress_local).is_multicast
 
     def as_response_address(self):
         if not self.is_multicast_locally:

--- a/aiocoap/util/socknumbers.py
+++ b/aiocoap/util/socknumbers.py
@@ -42,6 +42,8 @@ except NameError:
     # Not attempting to make any guesses for other platforms; the udp6 module
     # will fail to import where it needs the specifics
 
+IP_PKTINFO = 8
+
 try:
     from IN import IPV6_RECVERR, IP_RECVERR
 except (ImportError, NameError):


### PR DESCRIPTION
Allow setting of incoming and outgoing interfaces for multicast to make it independent from existing unicast default routes.
Allow setting the local IP address of the COAP socket.
