### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
     author_email="c.amsuess@energyharvesting.at",
     url="https://github.com/chrysn/aiocoap",
 
+    license='MIT',
     keywords=['coap', 'asyncio', 'iot'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Add license tag which can be read by third-parties like PyPI or `pyp2rpm`.