### PR TITLE
Fix event exception check before warning log

### DIFF
--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -751,12 +751,12 @@ class Request(interfaces.Request, BaseUnicastRequest):
                 self.observation.error(next_event.exception)
                 if not next_event.is_last:
                     self._plumbing_request.stop_interest()
-                if not isinstance(first_event.exception, error.Error):
+                if not isinstance(next_event.exception, error.Error):
                     self.log.warning(
                            "An exception that is not an aiocoap Error was "
                            "raised from a transport during an observation; "
                            "please report this as a bug in aiocoap: %r",
-                           first_event.exception)
+                           next_event.exception)
                 return
 
             self._add_response_properties(next_event.message, self._plumbing_request.request)


### PR DESCRIPTION
- In my testing, the code on master generates an unexpected warning on shutdown.
  ```
  2020-09-04 16:38:46 WARNING (MainThread) [coap] An exception that is not an aiocoap Error was raised from a transport during an observation; please report this as a bug in aiocoap: None
  ```
- My guess is that it's a copy paste mistake from the other similar check and warning in this module.
  https://github.com/chrysn/aiocoap/blob/4c6cd509da48051742366d6e8ecc1c1e18eeb7f5/aiocoap/protocol.py#L707-L711
- The change in this PR resolves the warning.