### PR TITLE
Avoid dict changed size during iteration in token manager

### DIFF
--- a/aiocoap/tokenmanager.py
+++ b/aiocoap/tokenmanager.py
@@ -42,7 +42,7 @@ class TokenManager(interfaces.RequestInterface, interfaces.TokenManager):
         return self.context.client_credentials
 
     async def shutdown(self):
-        for request in self.outgoing_requests.values():
+        for request in dict(self.outgoing_requests).values():
             request.add_exception(error.LibraryShutdown())
         self.outgoing_requests = None
 


### PR DESCRIPTION
- In my testing of this library master branch within Home Assistant and using pytradfri, there's a RuntimeError on shutdown.

  ```
  Traceback (most recent call last):
    File "/home/martin/Dev/home-assistant/home-assistant/homeassistant/components/tradfri/__init__.py", line 112, in on_hass_stop
      await factory.shutdown()
    File "/home/martin/Dev/pytradfri/pytradfri/api/aiocoap_api.py", line 89, in shutdown
      await self._reset_protocol(exc)
    File "/home/martin/Dev/pytradfri/pytradfri/api/aiocoap_api.py", line 79, in _reset_protocol
      await protocol.shutdown()
    File "/home/martin/Dev/aiocoap/aiocoap/protocol.py", line 322, in shutdown
      await item
    File "/home/martin/Dev/aiocoap/aiocoap/tokenmanager.py", line 45, in shutdown
      for request in self.outgoing_requests.values():
  RuntimeError: dictionary changed size during iteration
  ```
- From what I can follow the code it seems that at least one of the event callback pops items from this dict. The event callbacks are called on shutdown when adding the shutdown exception to the request.
  https://github.com/chrysn/aiocoap/blob/4c6cd509da48051742366d6e8ecc1c1e18eeb7f5/aiocoap/tokenmanager.py#L247

- Copying the dict before iteration resolves the error.