### PR TITLE
Allow DTLS client connection to be cancelled

### DIFF
--- a/aiocoap/transports/tinydtls.py
+++ b/aiocoap/transports/tinydtls.py
@@ -187,6 +187,8 @@ class DTLSClientConnection(interfaces.EndpointAddress):
         except OSError as e:
             self.log.debug("Expressing exception %r as errno %d.", e, e.errno)
             self.coaptransport.ctx.dispatch_error(e.errno, self)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             self.log.error("Exception %r can not be represented as errno, setting -1.", e)
             self.coaptransport.ctx.dispatch_error(-1, self)


### PR DESCRIPTION
- In my testing of this library with Home Assistant and pytradfri, on shutdown there's an error log for an asyncio CancelledError and later an AttributeError is raised.
  ```
  2020-09-04 17:20:02 ERROR (MainThread) [coap] Exception CancelledError() can not be represented as errno, setting -1.
  2020-09-04 17:20:04 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event homeassistant_final_write[L]>
  2020-09-04 17:20:04 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event homeassistant_close[L]>
  Error doing job: Task exception was never retrieved
  Traceback (most recent call last):
    File "/home/martin/Dev/aiocoap/aiocoap/transports/tinydtls.py", line 183, in _run
      message = await self._queue.get()
    File "/home/martin/Dev/aiocoap/aiocoap/util/asyncio/peekqueue.py", line 33, in get
      priority, first = await self._inner.get()
    File "/usr/lib/python3.7/asyncio/queues.py", line 159, in get
      await getter
  concurrent.futures._base.CancelledError

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/home/martin/Dev/aiocoap/aiocoap/transports/tinydtls.py", line 192, in _run
      self.coaptransport.ctx.dispatch_error(-1, self)
    File "/home/martin/Dev/aiocoap/aiocoap/messagemanager.py", line 116, in dispatch_error
      self.token_manager.dispatch_error(errno, remote)
    File "/home/martin/Dev/aiocoap/aiocoap/tokenmanager.py", line 100, in dispatch_error
      for key, request in self.outgoing_requests.items():
  AttributeError: 'NoneType' object has no attribute 'items'
  ```
- It looks like we're not catching the `CancelledError` before catching it with the broader `except Exception` and this stops the connection from canceling cleanly and this later causes the `AttributeError` since the shutdown clean up has already cleaned up stored outgoing requests.
- Specifically catching the `CancelledError` and re-raising it resolves the error and allows a shutdown without stacktrace. This is needed until Python 3.8 is the minimum version to allow cancelling coroutines. See https://bugs.python.org/issue32528.