### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     name=name,
     version=version,
     description=description,
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests*",)),
 
     author="Maciej Wasilak, Christian Amsüss",
     author_email="c.amsuess@energyharvesting.at",


### PR DESCRIPTION
Installing tests is not generally desirable in the first place, but particularly not in the global top level `tests` package.