### PR TITLE
Fix shutdown, when _tokenmanager isn't even set

### DIFF
--- a/aiocoap/transports/tcp.py
+++ b/aiocoap/transports/tcp.py
@@ -256,7 +256,7 @@ class _TCPPooling:
     def _dispatch_error(self, connection, exc):
         self._evict_from_pool(connection)
 
-        if self._tokenmanager is None:
+        if not hasattr(self, '_tokenmanager') or self._tokenmanager is None:
             if exc is not None:
                 self.log.warning("Ignoring late error during shutdown: %s", exc)
             else:


### PR DESCRIPTION
Hi,
I sometimes get this exception during shutdown:

```
WARNING:coap:Aborting connection: Server shutdown
ERROR:asyncio:Exception in callback _SelectorSocketTransport._call_connection_lost(None)
handle: <Handle _SelectorSocketTransport._call_connection_lost(None)>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.8/asyncio/selector_events.py", line 970, in _call_connection_lost
    super()._call_connection_lost(exc)
  File "/usr/local/lib/python3.8/asyncio/selector_events.py", line 728, in _call_connection_lost
    self._protocol.connection_lost(exc)
  File "/usr/local/lib/python3.8/site-packages/aiocoap/transports/tcp.py", line 167, in connection_lost
    self._ctx._dispatch_error(self, exc)
  File "/usr/local/lib/python3.8/site-packages/aiocoap/transports/tcp.py", line 259, in _dispatch_error
    if self._tokenmanager is None:
AttributeError: 'TCPClient' object has no attribute '_tokenmanager'
```

I think this fixes the issue.
Have a nice day