### PR TITLE
Add support for security policies in resource directory

### DIFF
--- a/aiocoap/cli/securitypolicy.cddl
+++ b/aiocoap/cli/securitypolicy.cddl
@@ -1,0 +1,36 @@
+security-policy = {
+    "sectors": sector-map,
+    ? "registrar_has_permissions": bool, ; Will default to "true" if not defined
+}
+
+sector-map = {
+    * tstr => sector-policy,
+}
+
+sector-policy = {
+    ? "endpoints": endpoint-map,
+    ? "default_policies": policy-map
+}
+
+endpoint-map = {
+    * tstr => endpoint-policy
+}
+
+endpoint-policy = {
+    "policies": policy-map
+}
+
+; These are the same as in credentials.cddl
+claim = uripattern / credential-reference
+uripattern = tstr .regexp "[^:]"
+credential-reference = tstr .regexp ":.+"
+
+policy-map = {
+    * claim => policy
+}
+
+policy = {
+    ? "write": bool,    ; Will default to "false" if not defined
+    ? "read": bool,     ; Will default to "false" if not defined
+    ? "create": bool,   ; Will default to "false" if not defined
+}


### PR DESCRIPTION
This PR extends the current resource directory implementation in `aiocoap/cli/rd.py` with basic support for security policies, making it possible to restrict access to specific endpoints, which can be useful for a number of use cases:
- Environments where clients expect a specific endpoint to be registered under a pre-defined name
- Environments where some registrations should be invisible to some clients based on their credentials

The configuration happens using a separate JSON file that needs to be provided with the `--security-policy` command line option.
The file format is currently described in the rd.py module description, a CDDL description (like in credentials.cddl) is ~~not included yet (but should be added before merging).~~ included in `aiocoap/cli/securitypolicy.cddl`.

This is my first pull request to this repository, I am open to feedback if there is anything I can improve.