### PR TITLE
fix(tokenmanager): only use new token if not set

### DIFF
--- a/aiocoap/tokenmanager.py
+++ b/aiocoap/tokenmanager.py
@@ -204,7 +204,8 @@ class TokenManager(interfaces.RequestInterface, interfaces.TokenManager):
 
         # FIXME: pick a suitably short one where available, and a longer one
         # for observations if many short ones are already in-flight
-        msg.token = self.next_token()
+        if msg.token == b'':
+            msg.token = self.next_token()
 
         self.log.debug("Sending request - Token: %s, Remote: %s", msg.token.hex(), msg.remote)
 


### PR DESCRIPTION
When setting a message token manually in a message like
```
request = Message(code=GET, uri='coap://localhost/time', token=b'1234')
```
the value gets overridden in the `aiocoap/tokenmanager.py`. This PR makes sure that the provided value is used.

This useful if you want to send a message with the same token from a previous request. I need this functionality to send a de-registering (`request.opt.observe = 1`) request to a CoAP server.