### PR TITLE
Fix a TypeError in aiocoap-rd

### DIFF
--- a/aiocoap/cli/rd.py
+++ b/aiocoap/cli/rd.py
@@ -405,7 +405,7 @@ class RegistrationResource(Resource):
         self.reg = registration
 
     async def render_get(self, request):
-        return link_format_from_message(request, self.reg.links)
+        return link_format_to_message(request, self.reg.links)
 
     def _update_params(self, msg):
         query = query_split(msg)


### PR DESCRIPTION
A GET request to /reg/1/ of aiocoap-rd causes a TypeError:

```
ERROR:coap-server:An exception occurred while rendering a resource: TypeError('link_format_from_message() takes 1 positional argument but 2 were given')
Traceback (most recent call last):
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/protocol.py", line 393, in _render_to_plumbing_request
    await self._render_to_plumbing_request_inner(plumbing_request,
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/protocol.py", line 522, in _render_to_plumbing_request_inner
    response = await self.serversite.render(request)
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/cli/rd.py", line 664, in render
    return await Site.render(self, request)
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/resource.py", line 369, in render
    return await child.render(subrequest)
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/cli/rd.py", line 444, in render
    return await entity.render(request.copy(uri_path=()))
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/resource.py", line 117, in render
    response = await m(request)
  File "/home/LP-HAW/.local/lib/python3.10/site-packages/aiocoap/cli/rd.py", line 407, in render_get
    return link_format_from_message(request, self.reg.links)
TypeError: link_format_from_message() takes 1 positional argument but 2 were given
```


To fix this error `link_format_to_message` should be called instead of `link_format_from_message`