### PR TITLE
python 3.11: workaround mass test failure due to _Outcome changes

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,7 +40,14 @@ def is_test_successful(testcase):
     raising errors. This is supposed to be used in tearDown handlers on self
     when additional debug information can be shown that would otherwise be
     discarded, or to skip tests during teardown that are bound to fail."""
-    return not any(e[1] is not None for e in testcase._outcome.errors)
+    errors = getattr(testcase._outcome, 'errors', None)
+    if errors is None:
+        # FIXME after https://github.com/python/cpython/issues/75039,
+        # errors is not longer assigned to.  This will need a better solution.
+        # Per comment below, result is uglier logs on failure.
+        return True
+    else:
+        return not any(e[1] is not None for e in testcase._outcome.errors)
 
 def asynctest(method):
     """Decorator for async WithAsyncLoop fixtures methods that runs them from

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 ;
 ; For uvloop not being tested with pyp3, see
 ; https://github.com/chrysn/aiocoap/issues/193.
-envlist = {py37,py38,py39,py310,pypy3}-{noextras,allextras},py38-uvloop
+envlist = {py37,py38,py39,py310,py311,pypy3}-{noextras,allextras},py38-uvloop
 
 [testenv]
 deps =


### PR DESCRIPTION
* Add workaround to fixtures to deal with changes to _Outcome in python 3.11
* Add python 3.11 to tox environments

With this workaround in place, it's easier to see the real test failures in python 3.11.
Will follow-up with separate issue about that.