### PR TITLE
Fix floor operation to limit payload to a multiple of 1024

### DIFF
--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -267,7 +267,7 @@ class Message(object):
         """Extract block from current message."""
         if size_exp == 7:
             start = number * 1024
-            size = 1024 * max_bert_size // 1024
+            size = 1024 * ( max_bert_size // 1024 )
         else:
             size = 2 ** (size_exp + 4)
             start = number * size


### PR DESCRIPTION
It occurred, that on TCP block transport the payload size was invalid.

Error log in client:
```
<ERROR> asyncio - Task exception was never retrieved
future: <Task finished name='Task-4' coro=<CoapClient.get_content() done, defined at /workspace/src/coap_client.py:240> exception=NetworkError('None')>
Traceback (most recent call last):
  File "/workspace/src/coap_client.py", line 248, in get_content
    resp = await self.get('/events')
  File "/workspace/src/coap_client.py", line 113, in get
    response = await self._send(path)
  File "/workspace/src/coap_client.py", line 68, in _send
    return await self._context.request(request).response
  File "/usr/local/lib/python3.8/site-packages/aiocoap/protocol.py", line 842, in _run_outer
    await cls._run(app_request, response, weak_observation, protocol, log)
  File "/usr/local/lib/python3.8/site-packages/aiocoap/protocol.py", line 894, in _run
    blockresponse = await blockrequest.response
aiocoap.error.NetworkError: None
```

Wireshark log:
![Screenshot from 2023-02-02 11-39-49](https://user-images.githubusercontent.com/10007694/217781710-6b121375-d017-4be9-b4ae-a84d999f9e3b.png)
