### PR TITLE
Use cbor-diag notation

### DIFF
--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -257,27 +257,26 @@ async def single_request(args, context):
                     )
             if request_classification in ('cbor', 'cbor-seq'):
                 try:
-                    import cbor2 as cbor
+                    import cbor_diag
                 except ImportError as e:
-                    raise parser.error("CBOR recoding not available (%s)" % e)
-                import json
+                    raise parser.error(f"CBOR recoding not available ({e})")
+
                 try:
-                    decoded = json.loads(options.payload)
-                except json.JSONDecodeError as e:
-                    import ast
-                    try:
-                        decoded = ast.literal_eval(options.payload)
-                    except ValueError:
-                        raise parser.error("JSON and Python recoding failed. Make sure quotation marks are escaped from the shell. JSON error: %s" % e)
+                    encoded = cbor_diag.diag2cbor(options.payload)
+                except ValueError as e:
+                    raise parser.error(f"Parsing CBOR diagnostic notation failed. Make sure quotation marks are escaped from the shell. Error: {e}")
 
                 if request_classification == 'cbor-seq':
-                    if type(decoded) not in (list, tuple):
-                        raise parser.error("CBOR sequence recoding requires a list or tuple top-level element.")
-                    items = decoded
+                    try:
+                        import cbor2
+                    except ImportError as e:
+                        raise parser.error(f"CBOR sequence recoding not available ({e})")
+                    decoded = cbor2.loads(encoded)
+                    if not isinstance(decoded, list):
+                        raise parser.error("CBOR sequence recoding requires an array as the top-level element.")
+                    request.payload = b"".join(cbor2.dumps(d) for d in decoded)
                 else:
-                    items = [decoded]
-
-                request.payload = b"".join(cbor.dumps(i) for i in items)
+                    request.payload = encoded
             else:
                 request.payload = options.payload.encode('utf8')
 

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -42,7 +42,7 @@ def build_parser():
     p.add_argument('--proxy', help="Relay the CoAP request to a proxy for execution", metavar="URI")
     p.add_argument('--payload', help="Send X as request payload (eg. with a PUT). If X starts with an '@', its remainder is treated as a file name and read from; '@-' reads from the console. Non-file data may be recoded, see --content-format.", metavar="X")
     p.add_argument('--payload-initial-szx', help="Size exponent to limit the initial block's size (0 ≙ 16 Byte, 6 ≙ 1024 Byte)", metavar="SZX", type=int)
-    p.add_argument('--content-format', help="Content format of the --payload data. If a known format is given and --payload has a non-file argument, conversion is attempted (currently only JSON/Python-literals to CBOR).", metavar="MIME")
+    p.add_argument('--content-format', help="Content format of the --payload data. If a known format is given and --payload has a non-file argument, the payload is converted from CBOR Diagnostic Notation.", metavar="MIME")
     p.add_argument('--no-set-hostname', help="Suppress transmission of Uri-Host even if the host name is not an IP literal", dest="set_hostname", action='store_false', default=True)
     p.add_argument('-v', '--verbose', help="Increase the debug output", action="count")
     p.add_argument('-q', '--quiet', help="Decrease the debug output", action="count")

--- a/aiocoap/util/prettyprint.py
+++ b/aiocoap/util/prettyprint.py
@@ -126,7 +126,10 @@ def pretty_print(message):
             else:
                 info("CBOR message shown in Diagnostic Notation")
 
-            return (infos, 'text/x-cbor-dianostic', formatted)
+            # It's not exactly CDDL, but it's close enough that the syntax
+            # highlighting looks OK, and tolerant enough to not complain about
+            # missing leading barewords and "=" signs
+            return (infos, 'text/x-cddl', formatted)
         except ImportError:
             show_hex = "No CBOR pretty-printer available"
         except ValueError:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
         'oscore': ['cbor2', 'cryptography (>= 2.0)', 'filelock', 'ge25519'],
         'tinydtls': ['DTLSSocket >= 0.1.11a1'],
         'ws': ['websockets'],
-        'prettyprint': ['termcolor', 'cbor2', 'LinkHeader', 'pygments'],
+        'prettyprint': ['termcolor', 'cbor2', 'LinkHeader', 'pygments', 'cbor-diag'],
         'docs': ['sphinx', 'sphinx-argparse'], # extended below
         'all': [], # populated below, contains everything but documentation dependencies for easier installation
         }

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -88,8 +88,8 @@ class TestCommandlineClient(WithTestServer):
             self.assertTrue(b'    ' not in json_coloronly, "Indentation in color-printed JSON")
 
             cbor_formatted = subprocess.check_output(AIOCOAP_CLIENT + ['coap://' + self.servernetloc + '/answer', '--accept', 'application/cbor', '--pretty-print'])
-            # Concrete formatting may vary, as it depends on Python repr
-            self.assertEqual(cbor_formatted, b"{'answer': 42}")
+            # Concrete formatting depends on cbor-diag package
+            self.assertEqual(cbor_formatted, b'{"answer": 42_0}')
 
     @no_warnings
     @asynctest


### PR DESCRIPTION
Incomplete; so far, this only alters the output, but does not accept diagnostic input

ToDo:
* [ ] Find the right Media Type to pass on to pygments
* [ ] Convince pygments to highlight diagnostic notation
* [x] Accept diagnostic notation as input
* [x] Look through aiocoap-client to see whether any points that document the old behavior
* [ ] Consider whether it's worth doing a transition period with a warning (probably not)