### PR TITLE
README: Link to wikipedia instead of coap.technology

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Protocol`_.
 It is written in Python 3 using its `native asyncio`_ methods to facilitate
 concurrent operations while maintaining an easy to use interface.
 
-.. _`Constrained Application Protocol`: http://coap.technology/
+.. _`Constrained Application Protocol`: https://en.wikipedia.org/wiki/Constrained_Application_Protocol
 .. _`native asyncio`: https://docs.python.org/3/library/asyncio
 
 Usage


### PR DESCRIPTION
coap.technology doesn't exist at least for now. This patch points to the Wikipedia article of CoAP.