### PR TITLE
dependencies: Avoid breakage through cryptography 42

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,10 @@ aiocoap-fileserver = "aiocoap.cli.fileserver:FileServerProgram.sync_main"
 linkheader = []
 # ge25519 is a workaround for
 # <https://github.com/pyca/cryptography/issues/5557>; being pure python it's
-# light enough to not warrant a dedicated group-oscore extra.
-oscore = [ "cbor2", "cryptography (>= 2.0)", "filelock", "ge25519" ]
+# light enough to not warrant a dedicated group-oscore extra. Note that the
+# workaround depends on cryptography features that went away in 42
+# <https://github.com/pyca/cryptography/pull/9086#issuecomment-2009571443>
+oscore = [ "cbor2", "cryptography (>= 2.0, < 42)", "filelock", "ge25519" ]
 tinydtls = [ "DTLSSocket >= 0.1.11a1" ]
 # technically websockets is not needed when running on pyodide, but that's hard
 # to express here
@@ -62,7 +64,7 @@ docs = [ "sphinx >= 5", "sphinx-argparse" ]
 #
 # when updating this, also check what is needed to build in .readthedocs.yaml
 all = [
-    "cbor2", "cryptography (>= 2.0)", "filelock", "ge25519",
+    "cbor2", "cryptography (>= 2.0, < 42)", "filelock", "ge25519",
     "DTLSSocket >= 0.1.11a1",
     "websockets",
     "termcolor", "cbor2", "pygments", "cbor-diag",


### PR DESCRIPTION
That version removed
cryptography.hazmat.backends.default_backend().x25519_load_private_byte(), which was part of the Group OSCORE key transformation.

See-Also: https://github.com/pyca/cryptography/pull/9086#issuecomment-2009571443