### PR TITLE
cryptography: Use public API, restoring compatibility with versions >= 42

### DIFF
--- a/aiocoap/util/cryptography_additions.py
+++ b/aiocoap/util/cryptography_additions.py
@@ -28,7 +28,6 @@ def sk_to_curve25519(ed: ed25519.Ed25519PrivateKey) -> x25519.X25519PrivateKey:
     # as proposed in https://github.com/pyca/cryptography/issues/5557#issuecomment-739339132
 
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.backends.openssl.backend import backend
 
     hasher = hashes.Hash(hashes.SHA512())
     hasher.update(raw)
@@ -38,7 +37,7 @@ def sk_to_curve25519(ed: ed25519.Ed25519PrivateKey) -> x25519.X25519PrivateKey:
     h[31] &= 127
     h[31] |= 64
 
-    return backend.x25519_load_private_bytes(h[0:32])
+    return x25519.X25519PrivateKey.from_private_bytes(h[0:32])
 
 def pk_to_curve25519(ed: ed25519.Ed25519PublicKey) -> x25519.X25519PublicKey:
     raw = ed.public_bytes(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ linkheader = []
 # ge25519 is a workaround for
 # <https://github.com/pyca/cryptography/issues/5557>; being pure python it's
 # light enough to not warrant a dedicated group-oscore extra.
-oscore = [ "cbor2", "cryptography (>= 2.0)", "filelock", "ge25519" ]
+oscore = [ "cbor2", "cryptography (>= 2.5)", "filelock", "ge25519" ]
 tinydtls = [ "DTLSSocket >= 0.1.11a1" ]
 # technically websockets is not needed when running on pyodide, but that's hard
 # to express here
@@ -62,7 +62,7 @@ docs = [ "sphinx >= 5", "sphinx-argparse" ]
 #
 # when updating this, also check what is needed to build in .readthedocs.yaml
 all = [
-    "cbor2", "cryptography (>= 2.0)", "filelock", "ge25519",
+    "cbor2", "cryptography (>= 2.5)", "filelock", "ge25519",
     "DTLSSocket >= 0.1.11a1",
     "websockets",
     "termcolor", "cbor2", "pygments", "cbor-diag",


### PR DESCRIPTION
Replaces: https://github.com/chrysn/aiocoap/pull/341

In 42, the private `cryptography.hazmat.backends.default_backend().x25519_load_private_byte()` was removed; this uses the equivalent public version that is available since 2.5.