### PR TITLE
Error enhancements

### DIFF
--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -313,6 +313,9 @@ async def single_request(args, context):
             sys.exit(1)
         except aiocoap.error.NetworkError as e:
             print("Network error:", e, file=sys.stderr)
+            extra_help = e.extra_help()
+            if extra_help:
+                print("Debugging hint:", extra_help, file=sys.stderr)
             sys.exit(1)
         # Fallback while not all backends raise NetworkErrors
         except OSError as e:

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -325,6 +325,11 @@ async def single_request(args, context):
             if not text:
                 # eg ConnectionResetError flying out of a misconfigured SSL server
                 text = type(e)
+            print("Warning: OS errors should not be raised this way any more.", file=sys.stderr)
+            # not telling what to do precisely: the form already tells users to
+            # include `aiocoap.cli.defaults` output, which is exactly what we
+            # need.
+            print(f"Even if the cause of the error itself is clear, please file an issue at {aiocoap.meta.bugreport_uri}.", file=sys.stderr)
             print("Error:", text, file=sys.stderr)
             sys.exit(1)
 

--- a/aiocoap/meta.py
+++ b/aiocoap/meta.py
@@ -14,3 +14,6 @@ version = "0.4.7.post0"
 #: This is used the same way as `version` but when a URI is required, for
 #: example as a default value for .well-known/core's rel=impl-info link.
 library_uri = "https://christian.amsuess.com/tools/aiocoap/#version-" + version
+
+#: URI used in error messages that ask the user to file a bug report
+bugreport_uri = "https://github.com/chrysn/aiocoap/issues"

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -42,6 +42,8 @@ and the options can not be added easily to your platform, consider using the
 
 import asyncio
 import contextvars
+import errno
+import os
 import socket
 import ipaddress
 import struct
@@ -506,13 +508,13 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
     def datagram_errqueue_received(self, data, ancdata, flags, address):
         assert flags == socknumbers.MSG_ERRQUEUE, "Received non-error data through the errqueue"
         pktinfo = None
-        errno = None
+        errno_value = None
         for cmsg_level, cmsg_type, cmsg_data in ancdata:
             assert cmsg_level == socket.IPPROTO_IPV6, "Received non-IPv6 protocol through the errqueue"
             if cmsg_type == socknumbers.IPV6_RECVERR:
                 extended_err = SockExtendedErr.load(cmsg_data)
                 self.log.debug("Socket error recevied, details: %s", extended_err)
-                errno = extended_err.ee_errno
+                errno_value = extended_err.ee_errno
             elif cmsg_level == socket.IPPROTO_IPV6 and cmsg_type == socknumbers.IPV6_PKTINFO:
                 pktinfo = cmsg_data
             else:
@@ -525,7 +527,10 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
         # port should err out.
 
         try:
-            self._ctx.dispatch_error(OSError(errno, "received through errqueue"), remote)
+            text = os.strerror(errno_value)
+            symbol = errno.errorcode.get(errno_value, None)
+            symbol = "" if symbol is None else f"{symbol}, "
+            self._ctx.dispatch_error(OSError(errno_value, f"{text} ({symbol}received through errqueue)"), remote)
         except BaseException as exc:
             # Catching here because util.asyncio.recvmsg inherits
             # _SelectorDatagramTransport's bad handling of callback errors;

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -544,8 +544,7 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
         remote = self._remote_being_sent_to.get()
 
         if remote is None:
-            # TODO: Are there any errors left that wind up here? (sending to 127.0.0.0 takes the later half of this function)
-            self.log.error("Error received in situation with no way to to determine which sending caused the error; this should be accompanied by an error in another code path: %s", exc)
+            self.log.info("Error received in situation with no way to to determine which sending caused the error; this should be accompanied by an error in another code path: %s", exc)
             return
 
         try:


### PR DESCRIPTION
This should close https://github.com/chrysn/aiocoap/issues/348

@Teufelchen1, does this look good to you?

```
$ ./aiocoap-client coap://localhost/
Network error: [Errno 111] Connection refused (ECONNREFUSED, received through
errqueue)
Debugging hint: The remote host could be reached, but reported that
the requested port is not open. Check whether a CoAP server is running at the
address, or whether it is running on a different port.
$ ./aiocoap-client 'coap://[2001:db8::1]'
Network error: [Errno 101] Network is unreachable (ENETUNREACH, received
through errqueue)
Debugging hint: No way of contacting the remote network could be found. This
may be due to lack of IPv6 connectivity, lack of a concrete route (eg. trying
to reach a private use network which there is no route to). Tools for debugging
in the next step could be ping or traceroute.
./aiocoap-client 'coap://[fe80::1]'
Network error: [Errno 113] No route to host (EHOSTUNREACH, received through
errqueue)
Debugging hint: No way of contacting the remote host could be found. This could
be because a host on the local network is offline or firewalled. Tools for
debugging in the next step could be ping or traceroute.
$ ./aiocoap-client 'coap://255.255.255.255'
Network error: [Errno 13] Permission denied
Debugging hint: The operating system refused to send the request. For example,
this can occur when attempting to send broadcast requests instead of multicast
requests.
```