### PR TITLE
Allow setting remote block size for block1

### DIFF
--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -403,11 +403,7 @@ async def single_request(args, context):
                 request.payload = options.payload.encode("utf8")
 
     if options.payload_initial_szx is not None:
-        request.opt.block1 = aiocoap.optiontypes.BlockOption.BlockwiseTuple(
-            0,
-            False,
-            options.payload_initial_szx,
-        )
+        request.remote.maximum_block_size_exp = options.payload_initial_szx
 
     if options.proxy is None:
         interface = context

--- a/aiocoap/interfaces.py
+++ b/aiocoap/interfaces.py
@@ -284,13 +284,22 @@ class RequestProvider(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def request(self, request_message):
+    def request(self, request_message, handle_blockwise=True):
         """Create and act on a :class:`Request` object that will be handled
         according to the provider's implementation.
 
         Note that the request is not necessarily sent on the wire immediately;
         it may (but, depend on the transport does not necessarily) rely on the
         response to be waited for.
+
+        If handle_blockwise is True (the default), the request provider will
+        split the request and/or collect the response parts automatically. The
+        block size indicated by the remote is used, and can be decreased by
+        setting the message's :attr:`.remote.maximum_block_size_exp
+        <aiocoap.interfaces.EndpointAddress.maximum_block_size_exp>` property.
+        Note that by being a property of the remote, this may affect other
+        block-wise operations on the same remote -- this should be desirable
+        behavior.
 
         :meta private:
             (not actually private, just hiding from automodule due to being

--- a/aiocoap/interfaces.py
+++ b/aiocoap/interfaces.py
@@ -66,7 +66,7 @@ class EndpointAddress(metaclass=abc.ABCMeta):
     participant 0x01 of the OSCAP key 0x..., routed over <another
     EndpointAddress>".
 
-    EndpointAddresses are only concstructed by MessageInterface objects,
+    EndpointAddresses are only constructed by MessageInterface objects,
     either for incoming messages or when populating a message's .remote in
     :meth:`MessageInterface.determine_remote`.
 
@@ -285,7 +285,7 @@ class RequestProvider(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def request(self, request_message):
-        """Create and act on a a :class:`Request` object that will be handled
+        """Create and act on a :class:`Request` object that will be handled
         according to the provider's implementation.
 
         Note that the request is not necessarily sent on the wire immediately;

--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 from . import error, optiontypes
 from .numbers.codes import Code, CHANGED
 from .numbers.types import Type
-from .numbers.constants import TransportTuning
+from .numbers.constants import TransportTuning, MAX_REGULAR_BLOCK_SIZE_EXP
 from .options import Options
 from .util import hostportjoin, hostportsplit, Sentinel, quote_nonascii
 from .util.uri import quote_factory, unreserved, sub_delims
@@ -682,6 +682,9 @@ class UndecidedRemote(
     >>> UndecidedRemote("coap+tcp", "[::0001]:1234")
     UndecidedRemote(scheme='coap+tcp', hostinfo='[::1]:1234')
     """
+
+    # This is settable per instance, for other transports to pick it up.
+    maximum_block_size_exp = MAX_REGULAR_BLOCK_SIZE_EXP
 
     def __new__(cls, scheme, hostinfo):
         if "[" in hostinfo:

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -789,6 +789,11 @@ class BlockwiseRequest(BaseUnicastRequest, interfaces.Request):
         size_exp = app_request.remote.maximum_block_size_exp
 
         if app_request.opt.block1 is not None:
+            warnings.warn(
+                "Setting a block1 option in a managed block-wise transfer is deprecated. Instead, set request.remote.maximum_block_size_exp to the desired value",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             assert (
                 app_request.opt.block1.block_number == 0
             ), "Unexpected block number in app_request"

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -834,7 +834,14 @@ class BlockwiseRequest(BaseUnicastRequest, interfaces.Request):
 
             # store for future blocks to ensure that the next blocks will be
             # sent from the same source address (in the UDP case; for many
-            # other transports it won't matter).
+            # other transports it won't matter). carrying along locally set block size limitation
+            if (
+                app_request.remote.maximum_block_size_exp
+                < blockresponse.remote.maximum_block_size_exp
+            ):
+                blockresponse.remote.maximum_block_size_exp = (
+                    app_request.remote.maximum_block_size_exp
+                )
             app_request.remote = blockresponse.remote
 
             if blockresponse.opt.block1 is None:

--- a/aiocoap/transports/generic_udp.py
+++ b/aiocoap/transports/generic_udp.py
@@ -69,4 +69,7 @@ class GenericMessageInterface(interfaces.MessageInterface):
                 "No location found to send message to (neither in .opt.uri_host nor in .remote)"
             )
 
-        return await self._pool.connect((host, port))
+        result = await self._pool.connect((host, port))
+        if request.remote.maximum_block_size_exp < result.maximum_block_size_exp:
+            result.maximum_block_size_exp = request.remote.maximum_block_size_exp
+        return result

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -526,7 +526,10 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
             local = None
 
         sockaddr = ip, port, flowinfo, scopeid
-        return UDP6EndpointAddress(sockaddr, self, pktinfo=local)
+        result = UDP6EndpointAddress(sockaddr, self, pktinfo=local)
+        if request.remote.maximum_block_size_exp < result.maximum_block_size_exp:
+            result.maximum_block_size_exp = request.remote.maximum_block_size_exp
+        return result
 
     #
     # implementing the typical DatagramProtocol interfaces.


### PR DESCRIPTION
While there has been a mechanism that'd allow clients to set the block1 size in outgoing requests without the server's support (eg. because a large initial request would not go through, or because the server would not limit the block size to an efficient value), that was never properly documented.

A newer way of setting per-remote properties around maximum block sizes has been around and used in tests, but was only available at the server because usually only the server has a remote set that doesn't go through any post-processing.

This changes the block size of the undecided remote (which gets set on new requests with the scheme, host and port of the URI) to propagate to the final remote.

The change was prompted by https://github.com/chrysn/aiocoap/issues/359. @moonlight83340, could you try out whether
* the `request.remote.maximum_block_size_exp = 4` proposed earlier works for you with this branch, and
* whether the updated documentation would have helped you find this?