### PR TITLE
cli: Enhance ux on uri parsing

### DIFF
--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -583,6 +583,8 @@ class Message(object):
         """
 
         parsed = urllib.parse.urlparse(uri)
+        if parsed.scheme == '' and parsed.netloc == '':
+            parsed = urllib.parse.urlparse("coap://" + uri)
 
         if parsed.fragment:
             raise ValueError("Fragment identifiers can not be set on a request URI")


### PR DESCRIPTION
Moo 🐄,

when running `python3 aiocoap-client 192.168.1.77/.well-known/core` on the current master, you'll get:
```
AttributeError: 'NoneType' object has no attribute 'hostinfo'
```
<details>

```
Traceback (most recent call last):
  File "/<path>/aiocoap/aiocoap-client", line 12, in <module>
    aiocoap.cli.client.sync_main()
  File "/<path>/aiocoap/aiocoap/cli/client.py", line 557, in sync_main
    asyncio.run(single_request_with_context(args))
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/<path>/aiocoap/aiocoap/cli/client.py", line 492, in single_request_with_context
    await single_request(args, context)
  File "/<path>/aiocoap/aiocoap/cli/client.py", line 329, in single_request
    if not request.opt.uri_host and not request.unresolved_remote:
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<path>/aiocoap/aiocoap/message.py", line 627, in unresolved_remote
    return self.remote.hostinfo
           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'hostinfo'
```

</details>

This is because there is no scheme provided in the target URI. 
I propose a fix by guessing, based on missing scheme and missing netloc (`urllib.parse.urlparse` decides the IP is a path in that case) , that the user forgot to add the scheme and then adding the default scheme `coap://` automatically after which  the parsing is attempted again. 

I am not deeply into aiocoap so I expect this PR to break use cases I do not know about. Hence it is more an expression of preferred behavior, rather than a direct mergable patch.

Other thoughts:
* silently adding a scheme might be confusing, informing the user by printing "no scheme found, guessing coap://<user_arg>"
* While annoying, it might be cleaner to just bail "no scheme found or not supported, must be coap, coaps, coap+tcp, coaps+tcp, coap+ws or coaps+ws. For example: coap://<user_arg>"
