### PR TITLE
Enhance URI errors

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -125,7 +125,8 @@ steps:
       - reuse lint
 
   doc:
-    image: python:3
+    # FIXME: Use python:3 once lakers and cbor-diag have 3.13 wheels again.
+    image: python:3.12
     depends_on: []
     environment:
       FORCE_COLOR: "1"

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -322,10 +322,7 @@ async def single_request(args, context):
         request = aiocoap.Message(
             code=code, mtype=aiocoap.NON if options.non else aiocoap.CON
         )
-        try:
-            request.set_request_uri(options.url, set_uri_host=options.set_hostname)
-        except ValueError as e:
-            raise parser.error(e)
+        request.set_request_uri(options.url, set_uri_host=options.set_hostname)
 
         if options.accept:
             try:

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -423,11 +423,8 @@ async def single_request(args, context):
 
         try:
             response_data = await requester.response
-        except aiocoap.error.ResolutionError as e:
-            print("Name resolution error:", e, file=sys.stderr)
-            sys.exit(1)
-        except aiocoap.error.NetworkError as e:
-            print("Network error:", e, file=sys.stderr)
+        except aiocoap.error.HelpfulError as e:
+            print(str(e), file=sys.stderr)
             extra_help = e.extra_help()
             if extra_help:
                 print("Debugging hint:", extra_help, file=sys.stderr)

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -326,9 +326,6 @@ async def single_request(args, context):
     except ValueError as e:
         raise parser.error(e)
 
-    if not request.opt.uri_host and not request.unresolved_remote:
-        raise parser.error("Request URLs need to be absolute.")
-
     if options.accept:
         try:
             request.opt.accept = ContentFormat(int(options.accept))

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -422,7 +422,12 @@ async def single_request(args, context):
             response_data = await requester.response
         except aiocoap.error.HelpfulError as e:
             print(str(e), file=sys.stderr)
-            extra_help = e.extra_help()
+            extra_help = e.extra_help(
+                hints=dict(
+                    original_uri=options.url,
+                    request=request,
+                )
+            )
             if extra_help:
                 print("Debugging hint:", extra_help, file=sys.stderr)
             sys.exit(1)

--- a/aiocoap/cli/client.py
+++ b/aiocoap/cli/client.py
@@ -305,109 +305,109 @@ async def single_request(args, context):
     configure_logging((options.verbose or 0) - (options.quiet or 0))
 
     try:
-        code = getattr(
-            aiocoap.numbers.codes.Code,
-            options.method.upper().replace("IPATCH", "iPATCH"),
-        )
-    except AttributeError:
         try:
-            code = aiocoap.numbers.codes.Code(int(options.method))
-        except ValueError:
-            raise parser.error("Unknown method")
-
-    if options.credentials is not None:
-        apply_credentials(context, options.credentials, parser.error)
-
-    request = aiocoap.Message(
-        code=code, mtype=aiocoap.NON if options.non else aiocoap.CON
-    )
-    try:
-        request.set_request_uri(options.url, set_uri_host=options.set_hostname)
-    except ValueError as e:
-        raise parser.error(e)
-
-    if options.accept:
-        try:
-            request.opt.accept = ContentFormat(int(options.accept))
-        except ValueError:
-            try:
-                request.opt.accept = ContentFormat.by_media_type(options.accept)
-            except KeyError:
-                raise parser.error("Unknown accept type")
-
-    if options.observe:
-        request.opt.observe = 0
-        observation_is_over = asyncio.get_event_loop().create_future()
-
-    if options.content_format:
-        try:
-            request.opt.content_format = ContentFormat(int(options.content_format))
-        except ValueError:
-            try:
-                request.opt.content_format = ContentFormat.by_media_type(
-                    options.content_format
-                )
-            except KeyError:
-                raise parser.error("Unknown content format")
-
-    if options.payload:
-        if options.payload.startswith("@"):
-            filename = options.payload[1:]
-            if filename == "-":
-                f = sys.stdin.buffer
-            else:
-                f = open(filename, "rb")
-            try:
-                request.payload = f.read()
-            except OSError as e:
-                raise parser.error("File could not be opened: %s" % e)
-        else:
-            request_classification = contenttype.categorize(
-                request.opt.content_format.media_type
-                if request.opt.content_format is not None
-                and request.opt.content_format.is_known()
-                else ""
+            code = getattr(
+                aiocoap.numbers.codes.Code,
+                options.method.upper().replace("IPATCH", "iPATCH"),
             )
-            if request_classification in ("cbor", "cbor-seq"):
-                try:
-                    import cbor_diag
-                except ImportError as e:
-                    raise parser.error(f"CBOR recoding not available ({e})")
+        except AttributeError:
+            try:
+                code = aiocoap.numbers.codes.Code(int(options.method))
+            except ValueError:
+                raise parser.error("Unknown method")
 
+        if options.credentials is not None:
+            apply_credentials(context, options.credentials, parser.error)
+
+        request = aiocoap.Message(
+            code=code, mtype=aiocoap.NON if options.non else aiocoap.CON
+        )
+        try:
+            request.set_request_uri(options.url, set_uri_host=options.set_hostname)
+        except ValueError as e:
+            raise parser.error(e)
+
+        if options.accept:
+            try:
+                request.opt.accept = ContentFormat(int(options.accept))
+            except ValueError:
                 try:
-                    encoded = cbor_diag.diag2cbor(options.payload)
-                except ValueError as e:
-                    raise parser.error(
-                        f"Parsing CBOR diagnostic notation failed. Make sure quotation marks are escaped from the shell. Error: {e}"
+                    request.opt.accept = ContentFormat.by_media_type(options.accept)
+                except KeyError:
+                    raise parser.error("Unknown accept type")
+
+        if options.observe:
+            request.opt.observe = 0
+            observation_is_over = asyncio.get_event_loop().create_future()
+
+        if options.content_format:
+            try:
+                request.opt.content_format = ContentFormat(int(options.content_format))
+            except ValueError:
+                try:
+                    request.opt.content_format = ContentFormat.by_media_type(
+                        options.content_format
                     )
+                except KeyError:
+                    raise parser.error("Unknown content format")
 
-                if request_classification == "cbor-seq":
-                    try:
-                        import cbor2
-                    except ImportError as e:
-                        raise parser.error(
-                            f"CBOR sequence recoding not available ({e})"
-                        )
-                    decoded = cbor2.loads(encoded)
-                    if not isinstance(decoded, list):
-                        raise parser.error(
-                            "CBOR sequence recoding requires an array as the top-level element."
-                        )
-                    request.payload = b"".join(cbor2.dumps(d) for d in decoded)
+        if options.payload:
+            if options.payload.startswith("@"):
+                filename = options.payload[1:]
+                if filename == "-":
+                    f = sys.stdin.buffer
                 else:
-                    request.payload = encoded
+                    f = open(filename, "rb")
+                try:
+                    request.payload = f.read()
+                except OSError as e:
+                    raise parser.error("File could not be opened: %s" % e)
             else:
-                request.payload = options.payload.encode("utf8")
+                request_classification = contenttype.categorize(
+                    request.opt.content_format.media_type
+                    if request.opt.content_format is not None
+                    and request.opt.content_format.is_known()
+                    else ""
+                )
+                if request_classification in ("cbor", "cbor-seq"):
+                    try:
+                        import cbor_diag
+                    except ImportError as e:
+                        raise parser.error(f"CBOR recoding not available ({e})")
 
-    if options.payload_initial_szx is not None:
-        request.remote.maximum_block_size_exp = options.payload_initial_szx
+                    try:
+                        encoded = cbor_diag.diag2cbor(options.payload)
+                    except ValueError as e:
+                        raise parser.error(
+                            f"Parsing CBOR diagnostic notation failed. Make sure quotation marks are escaped from the shell. Error: {e}"
+                        )
 
-    if options.proxy is None:
-        interface = context
-    else:
-        interface = aiocoap.proxy.client.ProxyForwarder(options.proxy, context)
+                    if request_classification == "cbor-seq":
+                        try:
+                            import cbor2
+                        except ImportError as e:
+                            raise parser.error(
+                                f"CBOR sequence recoding not available ({e})"
+                            )
+                        decoded = cbor2.loads(encoded)
+                        if not isinstance(decoded, list):
+                            raise parser.error(
+                                "CBOR sequence recoding requires an array as the top-level element."
+                            )
+                        request.payload = b"".join(cbor2.dumps(d) for d in decoded)
+                    else:
+                        request.payload = encoded
+                else:
+                    request.payload = options.payload.encode("utf8")
 
-    try:
+        if options.payload_initial_szx is not None:
+            request.remote.maximum_block_size_exp = options.payload_initial_szx
+
+        if options.proxy is None:
+            interface = context
+        else:
+            interface = aiocoap.proxy.client.ProxyForwarder(options.proxy, context)
+
         requested_uri = request.get_request_uri()
 
         requester = interface.request(request)
@@ -420,38 +420,11 @@ async def single_request(args, context):
 
         try:
             response_data = await requester.response
-        except aiocoap.error.HelpfulError as e:
-            print(str(e), file=sys.stderr)
-            extra_help = e.extra_help(
-                hints=dict(
-                    original_uri=options.url,
-                    request=request,
-                )
-            )
-            if extra_help:
-                print("Debugging hint:", extra_help, file=sys.stderr)
-            sys.exit(1)
-        # Fallback while not all backends raise NetworkErrors
-        except OSError as e:
-            text = str(e)
-            if not text:
-                text = repr(e)
-            if not text:
-                # eg ConnectionResetError flying out of a misconfigured SSL server
-                text = type(e)
-            print(
-                "Warning: OS errors should not be raised this way any more.",
-                file=sys.stderr,
-            )
-            # not telling what to do precisely: the form already tells users to
-            # include `aiocoap.cli.defaults` output, which is exactly what we
-            # need.
-            print(
-                f"Even if the cause of the error itself is clear, please file an issue at {aiocoap.meta.bugreport_uri}.",
-                file=sys.stderr,
-            )
-            print("Error:", text, file=sys.stderr)
-            sys.exit(1)
+        finally:
+            if not requester.response.done():
+                requester.response.cancel()
+            if options.observe and not requester.observation.cancelled:
+                requester.observation.cancel()
 
         response_uri = response_data.get_request_uri()
         if requested_uri != response_uri:
@@ -476,11 +449,38 @@ async def single_request(args, context):
         if options.observe:
             exit_reason = await observation_is_over
             print("Observation is over: %r" % (exit_reason,), file=sys.stderr)
-    finally:
-        if not requester.response.done():
-            requester.response.cancel()
-        if options.observe and not requester.observation.cancelled:
-            requester.observation.cancel()
+    except aiocoap.error.HelpfulError as e:
+        print(str(e), file=sys.stderr)
+        extra_help = e.extra_help(
+            hints=dict(
+                original_uri=options.url,
+                request=request,
+            )
+        )
+        if extra_help:
+            print("Debugging hint:", extra_help, file=sys.stderr)
+        sys.exit(1)
+    # Fallback while not all backends raise NetworkErrors
+    except OSError as e:
+        text = str(e)
+        if not text:
+            text = repr(e)
+        if not text:
+            # eg ConnectionResetError flying out of a misconfigured SSL server
+            text = type(e)
+        print(
+            "Warning: OS errors should not be raised this way any more.",
+            file=sys.stderr,
+        )
+        # not telling what to do precisely: the form already tells users to
+        # include `aiocoap.cli.defaults` output, which is exactly what we
+        # need.
+        print(
+            f"Even if the cause of the error itself is clear, please file an issue at {aiocoap.meta.bugreport_uri}.",
+            file=sys.stderr,
+        )
+        print("Error:", text, file=sys.stderr)
+        sys.exit(1)
 
 
 async def single_request_with_context(args):

--- a/aiocoap/error.py
+++ b/aiocoap/error.py
@@ -389,6 +389,16 @@ class AnonymousHost(Error):
     more once it is closed or even by another system."""
 
 
+class MissingRemoteError(HelpfulError):
+    """A request is sent without a .remote attribute"""
+
+    def __str__(self):
+        return "Error: The request URI needs to be absolute."
+
+    def extra_help(self):
+        return "Entering relative URIs such as /sensor/1 is only supported when there is already an established peer. Otherwise, URIs need to include a scheme and a hostname, eg. coap://example.com/sensor/1."
+
+
 __getattr__ = util.deprecation_getattr(
     {
         "UnsupportedMediaType": "UnsupportedContentFormat",

--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -634,6 +634,11 @@ class Message(object):
 
         self.remote = UndecidedRemote(parsed.scheme, parsed.netloc)
 
+        try:
+            _ = parsed.port
+        except ValueError as e:
+            raise error.MalformedUrlError("Port must be numeric") from e
+
         is_ip_literal = parsed.netloc.startswith("[") or (
             parsed.hostname.count(".") == 3
             and all(c in "0123456789." for c in parsed.hostname)

--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -580,32 +580,57 @@ class Message(object):
         breaks virtual hosts but makes message sizes smaller.
 
         This implements Section 6.4 of RFC7252.
+
+        This raises IncompleteUrlError if URI references are passed in (instead
+        of a full URI), and MalformedUrlError if the URI specification or the
+        library's expectations of URI shapes (eg. 'coap+tcp:no-slashes') are
+        violated.
         """
 
-        parsed = urllib.parse.urlparse(uri)
+        try:
+            parsed = urllib.parse.urlparse(uri)
+        except ValueError as e:
+            raise error.MalformedUrlError from e
 
         if parsed.fragment:
-            raise ValueError("Fragment identifiers can not be set on a request URI")
+            raise error.MalformedUrlError(
+                "Fragment identifiers can not be set on a request URI"
+            )
+
+        if not parsed.scheme:
+            raise error.IncompleteUrlError()
+
+        if not parsed.hostname:
+            raise error.MalformedUrlError("CoAP URIs need a hostname")
 
         if parsed.scheme not in coap_schemes:
             self.opt.proxy_uri = uri
             return
 
         if parsed.username or parsed.password:
-            raise ValueError("User name and password not supported.")
+            raise error.MalformedUrlError("User name and password not supported.")
 
-        if parsed.path not in ("", "/"):
-            self.opt.uri_path = [
-                urllib.parse.unquote(x) for x in parsed.path.split("/")[1:]
-            ]
-        else:
-            self.opt.uri_path = []
-        if parsed.query:
-            self.opt.uri_query = [
-                urllib.parse.unquote(x) for x in parsed.query.split("&")
-            ]
-        else:
-            self.opt.uri_query = []
+        try:
+            if parsed.path not in ("", "/"):
+                # FIXME: This tolerates incomplete % sequences.
+                self.opt.uri_path = [
+                    urllib.parse.unquote(x, errors="strict")
+                    for x in parsed.path.split("/")[1:]
+                ]
+            else:
+                self.opt.uri_path = []
+            if parsed.query:
+                # FIXME: This tolerates incomplete % sequences.
+                self.opt.uri_query = [
+                    urllib.parse.unquote(x, errors="strict")
+                    for x in parsed.query.split("&")
+                ]
+            else:
+                self.opt.uri_query = []
+        except UnicodeError as e:
+            raise error.MalformedUrlError(
+                "Percent encoded strings in CoAP URIs need to be UTF-8 encoded"
+            ) from e
 
         self.remote = UndecidedRemote(parsed.scheme, parsed.netloc)
 
@@ -616,9 +641,14 @@ class Message(object):
         )
 
         if set_uri_host and not is_ip_literal:
-            self.opt.uri_host = urllib.parse.unquote(parsed.hostname).translate(
-                _ascii_lowercase
-            )
+            try:
+                self.opt.uri_host = urllib.parse.unquote(
+                    parsed.hostname, errors="strict"
+                ).translate(_ascii_lowercase)
+            except UnicodeError as e:
+                raise error.MalformedUrlError(
+                    "Percent encoded strings in CoAP URI hosts need to be UTF-8 encoded"
+                ) from e
 
     # Deprecated accessors to moved functionality
 

--- a/aiocoap/message.py
+++ b/aiocoap/message.py
@@ -600,12 +600,12 @@ class Message(object):
         if not parsed.scheme:
             raise error.IncompleteUrlError()
 
-        if not parsed.hostname:
-            raise error.MalformedUrlError("CoAP URIs need a hostname")
-
         if parsed.scheme not in coap_schemes:
             self.opt.proxy_uri = uri
             return
+
+        if not parsed.hostname:
+            raise error.MalformedUrlError("CoAP URIs need a hostname")
 
         if parsed.username or parsed.password:
             raise error.MalformedUrlError("User name and password not supported.")

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -452,6 +452,8 @@ class Context(interfaces.RequestProvider):
     # change about messages and what can't after the remote has been thusly
     # populated).
     async def find_remote_and_interface(self, message):
+        if message.remote is None:
+            raise error.MissingRemoteError()
         for ri in self.request_interfaces:
             if await ri.fill_or_recognize_remote(message):
                 return ri

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -215,6 +215,21 @@ class TestCommandlineClient(WithTestServer):
                 stderr=subprocess.STDOUT,
             )
 
+        try:
+            # No full URI given
+            subprocess.check_output(
+                AIOCOAP_CLIENT + [self.servernetloc + "/empty"],
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as e:
+            self.assertTrue(
+                "The request URI needs to be absolute." in e.output.decode("utf8")
+            )
+        else:
+            raise AssertionError(
+                "Calling aiocoap-client without a full URI should fail."
+            )
+
     @no_warnings
     @asynctest
     async def test_noproxy(self):

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -223,12 +223,35 @@ class TestCommandlineClient(WithTestServer):
             )
         except subprocess.CalledProcessError as e:
             self.assertTrue(
+                "URL incomplete: Must start with a scheme." in e.output.decode("utf8")
+            )
+            # It must also show the extra_help
+            self.assertTrue(
                 "Most URLs in aiocoap need to be given with a scheme"
                 in e.output.decode("utf8")
             )
         else:
             raise AssertionError(
                 "Calling aiocoap-client without a full URI should fail."
+            )
+
+        try:
+            subprocess.check_output(
+                AIOCOAP_CLIENT + ["http://" + self.servernetloc + "/empty"],
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as e:
+            self.assertTrue(
+                "No remote endpoint set for request" in e.output.decode("utf8")
+            )
+            # Extra help even gives concrete output
+            self.assertTrue(
+                f"The message is set up for use with a proxy (because the scheme of 'http://{self.servernetloc}/empty' is not supported)"
+                in e.output.decode("utf8")
+            )
+        else:
+            raise AssertionError(
+                "Calling aiocoap-client without a HTTP URI should fail."
             )
 
     @no_warnings

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -223,7 +223,8 @@ class TestCommandlineClient(WithTestServer):
             )
         except subprocess.CalledProcessError as e:
             self.assertTrue(
-                "The request URI needs to be absolute." in e.output.decode("utf8")
+                "Most URLs in aiocoap need to be given with a scheme"
+                in e.output.decode("utf8")
             )
         else:
             raise AssertionError(


### PR DESCRIPTION
Closes: https://github.com/chrysn/aiocoap/pull/364

This should enhance the user experience around entering non-URI addresses:

```
$ aiocoap-client 'example.net/foo'
URL incomplete: Must start with a scheme.
Debugging hint: Most URLs in aiocoap need to be given with a scheme, eg. the 'coap' in 'coap://example.com/path'.
$ aiocoap-client 'https://example.net/foo'
Error: No remote endpoint set for request.
Debugging hint: The message is set up for use with a proxy (because the scheme of 'https://example.net/foo' is not supported), but no proxy was set.
$ aiocoap-client 'coap://[/'
Malformed URL: Invalid IPv6 URL
$ aiocoap-client 'coap://localhost/%ff'
Malformed URL: Percent encoded strings in CoAP URIs need to be UTF-8 encoded
```

(Note that following the hint to set a proxy sends you off into other bug country 🤦)

As bycatch, this cleans up very nonstandard behavior and error behavior of set_request_uri -- a few CoAP violating URIs are now rejected, and all exceptions are consistently MalformedUriError or IncompleteUriError (both of which are ValueError; previously raised AttributeError in some places were just wrong).

@teufelchen1, does this address your issues of #364?