### PR TITLE
Allow configuration of ETag length in fileserver

### DIFF
--- a/aiocoap/cli/fileserver.py
+++ b/aiocoap/cli/fileserver.py
@@ -79,11 +79,12 @@ class PreconditionFailed(error.ConstructionRenderableError):
 class FileServer(Resource, aiocoap.interfaces.ObservableResource):
     # Resource is only used to give the nice render_xxx methods
 
-    def __init__(self, root, log, *, write=False):
+    def __init__(self, root, log, *, write=False, etag_length=8):
         super().__init__()
         self.root = root
         self.log = log
         self.write = write
+        self.etag_length = etag_length
 
         self._observations = {}  # path -> [last_stat, [callbacks]]
 
@@ -138,11 +139,10 @@ class FileServer(Resource, aiocoap.interfaces.ObservableResource):
         # Only GETs to non-directory access handle it explicitly
         return False
 
-    @staticmethod
-    def hash_stat(stat):
+    def hash_stat(self, stat):
         # The subset that the author expects to (possibly) change if the file changes
         data = (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
-        return hashlib.sha256(repr(data).encode("ascii")).digest()[:8]
+        return hashlib.sha256(repr(data).encode("ascii")).digest()[:self.etag_length]
 
     async def render_get(self, request):
         if request.opt.uri_path == (".well-known", "core"):
@@ -157,17 +157,21 @@ class FileServer(Resource, aiocoap.interfaces.ObservableResource):
         except FileNotFoundError:
             raise NoSuchFile()
 
-        etag = self.hash_stat(st)
+        if self.etag_length:
+            etag = self.hash_stat(st)
 
-        if etag in request.opt.etags:
-            response = aiocoap.Message(code=codes.VALID)
-        else:
-            if S_ISDIR(st.st_mode):
-                response = await self.render_get_dir(request, path)
-            elif S_ISREG(st.st_mode):
-                response = await self.render_get_file(request, path)
+            if etag in request.opt.etags:
+                response = aiocoap.Message(code=codes.VALID)
+                response.opt.etag = etag
+                return response
 
-        response.opt.etag = etag
+        if S_ISDIR(st.st_mode):
+            response = await self.render_get_dir(request, path)
+        elif S_ISREG(st.st_mode):
+            response = await self.render_get_file(request, path)
+
+        if self.etag_length:
+            response.opt.etag = etag
         return response
 
     async def render_put(self, request):
@@ -353,6 +357,14 @@ class FileServerProgram(AsyncCLIDaemon):
             nargs="?",
             default=False,
         )
+        p.add_argument(
+            "--etag-length",
+            help="Control length of ETag, 0-32 (0 disables)",
+            metavar="LENGTH",
+            default=8,
+            type=int,
+            choices=range(0,33),
+        )
         p.add_argument("--write", help="Allow writes by any user", action="store_true")
         p.add_argument(
             "path",
@@ -367,7 +379,7 @@ class FileServerProgram(AsyncCLIDaemon):
         return p
 
     async def start_with_options(
-        self, path, verbosity=0, register=False, server_opts=None, write=False
+        self, path, verbosity=0, register=False, server_opts=None, write=False, etag_length=8
     ):
         log = logging.getLogger("fileserver")
         coaplog = logging.getLogger("coap-server")
@@ -381,7 +393,7 @@ class FileServerProgram(AsyncCLIDaemon):
             log.setLevel(logging.DEBUG)
             coaplog.setLevel(logging.DEBUG)
 
-        server = FileServer(path, log, write=write)
+        server = FileServer(path, log, write=write, etag_length=etag_length)
         if server_opts is None:
             self.context = await aiocoap.Context.create_server_context(server)
         else:


### PR DESCRIPTION
The length of the the ETag option can now be configured between 0 (completely disabled, for very constrained applications) and 32 bytes (Length of sha256), based on the desired overhead-to-accuracy tradeoff.

For very constrained applications, it can be disabled completely by setting it to 0 (saving 9 bytes).

I also considered adding an argument to disable the `Block2` option as well if the file fits into a single message, but that would save just two bytes.