### PR TITLE
ObservableResource: Copy updated_state() response for each observation.

### DIFF
--- a/aiocoap/resource.py
+++ b/aiocoap/resource.py
@@ -174,7 +174,7 @@ class ObservableResource(Resource, interfaces.ObservableResource):
         should be sent to observers."""
 
         for o in self._observations:
-            o.trigger(response)
+            o.trigger(response.copy() if response else response)
 
     def get_link_description(self):
         link = super(ObservableResource, self).get_link_description()


### PR DESCRIPTION
Otherwise the same object has its Message ID and (possibly) remote values changed each time it is sent, and the messagemanager can end up out of sync.

Also avoids *"WARNING Message ID set on to-be-sent message, this is probably unintended; clearing it."* if there is more than one observer registered.

Closes #401