### PR TITLE
Fix AttributeError in MessageManager.shutdown()

### DIFF
--- a/aiocoap/messagemanager.py
+++ b/aiocoap/messagemanager.py
@@ -70,11 +70,13 @@ class MessageManager(interfaces.TokenInterface, interfaces.MessageManager):
             getattr(self, "message_interface", "(unbound)"),
         )
 
-    @property
+       @property
     def client_credentials(self):
         return self.token_manager.client_credentials
 
     async def shutdown(self):
+        if self._active_exchanges is None:
+            return
         for messageerror_monitor, cancellable in self._active_exchanges.values():
             # Not calling messageerror_monitor: This is not message specific,
             # and its shutdown will take care of these things


### PR DESCRIPTION
Hi,

Under certain network conditions (e.g., unexpected connection loss with sleepy CoAP devices), `shutdown()` can be triggered when `self._active_exchanges` is already set to `None`. This currently raises an `AttributeError: 'NoneType' object has no attribute 'values'`.

This is a common issue affecting Home Assistant users (specifically using the Philips AirPurifier integration) when the device temporarily drops off the WiFi. 

This PR adds a simple `if` guard to `shutdown()` to gracefully return if `_active_exchanges` has already been cleared, preventing the crash and keeping the logs clean.

Thanks for your work on this library!
