### PR TITLE
Run some tests on Windows

### DIFF
--- a/.github/workflows/test-on-windows.yml
+++ b/.github/workflows/test-on-windows.yml
@@ -1,0 +1,24 @@
+name: Test Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # not bothering with old versions on Windows; this is tested more for
+          # curiosity anyway.
+          python-version: 3.14
+      - name: Install dependencies
+        run: |
+          pip install tox
+          python3 -m tox --notest -e py314-noextras
+      - name: Run tests
+        # -allextras would be nice, but DTLSSocket doesn't built
+        # out-of-the-box, and I don't want to cut it up too much
+        run: |
+          python3 -m tox -e py314-noextras

--- a/aiocoap/cli/rd.py
+++ b/aiocoap/cli/rd.py
@@ -324,8 +324,14 @@ class CommonRD:
 
         proxy = pop_single_arg(registration_parameters, "proxy")
 
-        if proxy is not None and proxy != "on":
+        if proxy is not None and proxy not in ("on", "yes", "ondemand"):
             raise error.BadRequest("Unsupported proxy value")
+
+        if proxy == "on":
+            # FIXME: Deprecate more visibly -- but this has been in the impl
+            # for quite some time, and is presumably used, given that the
+            # missing "yes" went uncontested for years.
+            self.log.warning("Client uses old proprietary value proxy=on")
 
         key = (ep, d)
 

--- a/aiocoap/cli/rd.py
+++ b/aiocoap/cli/rd.py
@@ -407,7 +407,7 @@ def link_format_from_message(message):
     This expects an explicit media type set on the response (or was explicitly requested)
     """
     certain_format = message.opt.content_format
-    if certain_format is None and hasattr(message, "request"):
+    if certain_format is None and message.request is not None:
         certain_format = message.request.opt.accept
     try:
         if certain_format == ContentFormat.LINKFORMAT:

--- a/aiocoap/cli/rd.py
+++ b/aiocoap/cli/rd.py
@@ -692,8 +692,12 @@ class SimpleRegistration(ThingWithCommonRD, Resource):
         get.code = aiocoap.GET
         get.opt.accept = ContentFormat.LINKFORMAT
 
-        # not trying to catch anything here -- the errors are most likely well renderable into the final response
-        response = await self.context.request(get).response_raising
+        try:
+            response = await self.context.request(get).response_raising
+        except error.ResponseWrappingError as e:
+            # Note that ResponseWrappingError is *not* itself renderable
+            raise error.BadRequest(f"got error {e.coapmessage.code.dotted}")
+        # No handling needed here: This raises renderable error
         links = link_format_from_message(response)
 
         if self.registration_warning:

--- a/aiocoap/defaults.py
+++ b/aiocoap/defaults.py
@@ -70,11 +70,11 @@ def get_default_clienttransports(*, loop=None, use_env=True):
         # There, the remaining ones would just raise NotImplementedError all over the place
         return
 
-    if sys.platform != "linux":
-        # udp6 was never reported to work on anything but linux; would happily
-        # add more platforms.
-        yield "simple6"
-        return
+    # if sys.platform != "linux":
+    #     # udp6 was never reported to work on anything but linux; would happily
+    #     # add more platforms.
+    #     yield "simple6"
+    #     return
 
     # on android it seems that it's only the AI_V4MAPPED that causes trouble,
     # that should be manageable in udp6 too.

--- a/aiocoap/interfaces.py
+++ b/aiocoap/interfaces.py
@@ -258,12 +258,21 @@ class TokenInterface(metaclass=abc.ABCMeta):
         Currently, it is up to the TokenInterface to unset the no_response
         option in response messages, and to possibly not send them."""
 
-    @abc.abstractmethod
     async def fill_or_recognize_remote(self, message):
         """Return True if the message is recognized to already have a .remote
         managedy by this TokenInterface, or return True and set a .remote on
         message if it should (by its unresolved remote or Uri-* options) be
         routed through this TokenInterface, or return False otherwise."""
+
+        raise RuntimeError("FIXME: Warn / deprecate and implemnent fallback")
+
+    @abc.abstractmethod
+    async def recognize_remote(self, message):
+        """Like :meth:`RequestInterface.recognize_remote`"""
+
+    @abc.abstractmethod
+    async def determine_remote(self, message):
+        """Like :meth:`RequestInterface.determine_remote`"""
 
 
 class TokenManager(metaclass=abc.ABCMeta):
@@ -274,13 +283,22 @@ class TokenManager(metaclass=abc.ABCMeta):
 class RequestInterface(metaclass=abc.ABCMeta):
     """A transport of CoAP."""
 
-    @abc.abstractmethod
     async def fill_or_recognize_remote(self, message):
-        pass
+        raise RuntimeError("FIXME: Warn / deprecate and implemnent fallback")
 
     @abc.abstractmethod
     def request(self, request: Pipe):
         pass
+
+    @abc.abstractmethod
+    async def recognize_remote(self, message):
+        """Return True if the remote of this message is currently expected to
+        be usable with this transport."""
+
+    @abc.abstractmethod
+    async def determine_remote(self, message):
+        """Return a remote if the transport expects to be able to deliver the
+        request based on its URI components."""
 
 
 class RequestProvider(metaclass=abc.ABCMeta):

--- a/aiocoap/interfaces.py
+++ b/aiocoap/interfaces.py
@@ -259,12 +259,19 @@ class TokenInterface(metaclass=abc.ABCMeta):
         option in response messages, and to possibly not send them."""
 
     async def fill_or_recognize_remote(self, message):
-        """Return True if the message is recognized to already have a .remote
-        managedy by this TokenInterface, or return True and set a .remote on
-        message if it should (by its unresolved remote or Uri-* options) be
-        routed through this TokenInterface, or return False otherwise."""
+        """Deprecated; like :meth:`RequestInterface.fill_or_recognize_remote`"""
 
-        raise RuntimeError("FIXME: Warn / deprecate and implemnent fallback")
+        warnings.warn(
+            "fill_or_recognize_remote has been split into recognize_remote and determine_remote",
+            DeprecationWarning,
+        )
+        if self.recognize_remote(message):
+            return True
+        remote = self.determine_remote(message)
+        if remote is not None:
+            message.remote = remote
+            return True
+        return False
 
     @abc.abstractmethod
     async def recognize_remote(self, message):
@@ -284,7 +291,29 @@ class RequestInterface(metaclass=abc.ABCMeta):
     """A transport of CoAP."""
 
     async def fill_or_recognize_remote(self, message):
-        raise RuntimeError("FIXME: Warn / deprecate and implemnent fallback")
+        """Deprecated method to perform
+        :meth:`RequestInterface.recognize_remote` and
+        :meth:`RequestInterface.determine_remote` in one go.
+
+        The implementation is only provided for compatibility, and will be
+        removed after the next release.
+
+        Return True if the message is recognized to already have a .remote
+        managedy by this TokenInterface, or return True and set a .remote on
+        message if it should (by its unresolved remote or Uri-* options) be
+        routed through this TokenInterface, or return False otherwise."""
+
+        warnings.warn(
+            "fill_or_recognize_remote has been split into recognize_remote and determine_remote",
+            DeprecationWarning,
+        )
+        if self.recognize_remote(message):
+            return True
+        remote = self.determine_remote(message)
+        if remote is not None:
+            message.remote = remote
+            return True
+        return False
 
     @abc.abstractmethod
     def request(self, request: Pipe):

--- a/aiocoap/interfaces.py
+++ b/aiocoap/interfaces.py
@@ -272,6 +272,8 @@ class TokenManager(metaclass=abc.ABCMeta):
 
 
 class RequestInterface(metaclass=abc.ABCMeta):
+    """A transport of CoAP."""
+
     @abc.abstractmethod
     async def fill_or_recognize_remote(self, message):
         pass

--- a/aiocoap/messagemanager.py
+++ b/aiocoap/messagemanager.py
@@ -402,15 +402,11 @@ class MessageManager(interfaces.TokenInterface, interfaces.MessageManager):
     # outgoing messages
     #
 
-    async def fill_or_recognize_remote(self, message):
-        if message.remote is not None:
-            if await self.message_interface.recognize_remote(message.remote):
-                return True
-        remote = await self.message_interface.determine_remote(message)
-        if remote is not None:
-            message.remote = remote
-            return True
-        return False
+    async def recognize_remote(self, message):
+        return await self.message_interface.recognize_remote(message.remote)
+
+    async def determine_remote(self, message):
+        return await self.message_interface.determine_remote(message)
 
     def send_message(self, message, messageerror_monitor):
         """Encode and send message. This takes care of retransmissions (if

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -131,7 +131,7 @@ class Context(interfaces.RequestProvider):
 
         self.serversite = serversite
 
-        self.request_interfaces = []
+        self.request_interfaces: list[interfaces.RequestInterface] = []
 
         self.client_credentials = client_credentials or CredentialsMap()
         self.server_credentials = server_credentials or CredentialsMap()

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -541,9 +541,10 @@ class Context(interfaces.RequestProvider):
     # populated).
     async def find_remote_and_interface(self, message):
         if message.remote is None:
-            raise error.MissingRemoteError()
-        for ri in self.request_interfaces:
-            if await ri.fill_or_recognize_remote(message):
+            if await ri.recognize_remote(message):
+                return ri
+            if remote := await ri.determine_remote(message):
+                message.remote = remote
                 return ri
         raise error.NoRequestInterface()
 

--- a/aiocoap/protocol.py
+++ b/aiocoap/protocol.py
@@ -541,8 +541,11 @@ class Context(interfaces.RequestProvider):
     # populated).
     async def find_remote_and_interface(self, message):
         if message.remote is None:
+            raise error.MissingRemoteError()
+        for ri in self.request_interfaces:
             if await ri.recognize_remote(message):
                 return ri
+        for ri in self.request_interfaces:
             if remote := await ri.determine_remote(message):
                 message.remote = remote
                 return ri

--- a/aiocoap/proxy/server.py
+++ b/aiocoap/proxy/server.py
@@ -153,6 +153,15 @@ class Proxy(interfaces.Resource):
     # resolution tree (it can't deal with None requests, which are used among
     # proxy implementations)
     async def render_to_pipe(self, pipe: Pipe) -> None:
+        # I'd rather not expand unconditionally, but if we don't do this here,
+        # we're too deep into render() etc to get out again. This is working on
+        # the assumption that all proxies are really at root.
+        #
+        # Workaround-For: https://github.com/chrysn/aiocoap/issues/414
+        try:
+            resource._expand_upa(pipe.request)
+        except error.BadOption:
+            pass
         await resource.Resource.render_to_pipe(self, pipe)  # type: ignore
 
 

--- a/aiocoap/resource.py
+++ b/aiocoap/resource.py
@@ -467,18 +467,12 @@ class Site(interfaces.ObservableResource, PathCapable):
         # need to agree on how the path is processed, even before we go into
         # the site dispatch -- so we better resolve this now (exercising our
         # liberties as a library proxy) and provide a consistent view.
-        if request.request.opt.uri_path_abbrev is not None:
-            if request.request.opt.uri_path:
-                # Conflicting options
-                raise error.BadOption()
-            try:
-                request.request.opt.uri_path = uri_path_abbrev._map[
-                    request.request.opt.uri_path_abbrev
-                ]
-            except KeyError:
-                # Unknown option
-                raise error.BadOption() from None
-            request.request.opt.uri_path_abbrev = None
+        #
+        # Factored out because other components that don't yet go through
+        # render_to_pipe
+        #
+        # Workaround-For: https://github.com/chrysn/aiocoap/issues/414
+        _expand_upa(request.request)
 
         try:
             child, subrequest = self._find_child_and_pathstripped_message(
@@ -491,3 +485,17 @@ class Site(interfaces.ObservableResource, PathCapable):
             # It probably is.
             request.request = subrequest
             return await child.render_to_pipe(request)
+
+
+def _expand_upa(request):
+    """Expands the Uri-Path-Abbrev option in-place, or raises BadOption"""
+    if request.opt.uri_path_abbrev is not None:
+        if request.opt.uri_path:
+            # Conflicting options
+            raise error.BadOption()
+        try:
+            request.opt.uri_path = uri_path_abbrev._map[request.opt.uri_path_abbrev]
+        except KeyError:
+            # Unknown option
+            raise error.BadOption() from None
+        request.opt.uri_path_abbrev = None

--- a/aiocoap/tokenmanager.py
+++ b/aiocoap/tokenmanager.py
@@ -211,8 +211,11 @@ class TokenManager(interfaces.RequestInterface, interfaces.TokenManager):
     # implement RequestInterface
     #
 
-    async def fill_or_recognize_remote(self, message):
-        return await self.token_interface.fill_or_recognize_remote(message)
+    async def recognize_remote(self, message):
+        return await self.token_interface.recognize_remote(message)
+
+    async def determine_remote(self, message):
+        return await self.token_interface.determine_remote(message)
 
     def request(self, request):
         if self.outgoing_requests is None:

--- a/aiocoap/transports/oscore.py
+++ b/aiocoap/transports/oscore.py
@@ -7,7 +7,7 @@
 # reasons why RequestInterface, TokenInterface and MessageInterface were split
 # in the first place.
 
-"""This module implements a RequestProvider for OSCORE. As such, it takes
+"""This module implements a RequestInterface for OSCORE. As such, it takes
 routing ownership of requests that it has a security context available for, and
 sends off the protected messages via another transport.
 
@@ -114,7 +114,7 @@ class OSCOREAddress(
         return (self.underlying_address.blockwise_key, detail)
 
 
-class TransportOSCORE(interfaces.RequestProvider):
+class TransportOSCORE(interfaces.RequestInterface):
     def __init__(self, context, forward_context):
         self._context = context
         self._wire = forward_context

--- a/aiocoap/transports/oscore.py
+++ b/aiocoap/transports/oscore.py
@@ -137,35 +137,36 @@ class TransportOSCORE(interfaces.RequestInterface):
     # implement RequestInterface
     #
 
-    async def fill_or_recognize_remote(self, message):
-        if isinstance(message.remote, OSCOREAddress):
-            return True
+    async def recognize_remote(self, message):
+        # There is just one of those
+        return isinstance(message.remote, OSCOREAddress)
+
+    async def determine_remote(self, message):
         if message.opt.oscore is not None:
             # double oscore is not specified; using this fact to make `._wire
             # is ._context` an option
-            return False
+            return None
         if message.opt.uri_path == (".well-known", "edhoc"):
             # FIXME better criteria based on next-hop?
-            return False
+            return None
 
         try:
             secctx = self._context.client_credentials.credentials_from_request(message)
         except credentials.CredentialsMissingError:
-            return False
+            return None
 
         # FIXME: it'd be better to have a "get me credentials *of this type* if they exist"
         if isinstance(secctx, oscore.CanProtect) or isinstance(
             secctx, edhoc.EdhocCredentials
         ):
-            message.remote = OSCOREAddress(secctx, message.remote)
             self.log.debug(
                 "Selecting OSCORE transport based on context %r for new request %r",
                 secctx,
                 message,
             )
-            return True
+            return OSCOREAddress(secctx, message.remote)
         else:
-            return False
+            return None
 
     def request(self, request):
         t = self.loop.create_task(

--- a/aiocoap/transports/slipmux.py
+++ b/aiocoap/transports/slipmux.py
@@ -359,6 +359,7 @@ class MessageInterfaceSlipmux(interfaces.MessageInterface):
             # See determine_remote: from the current API, this is the only
             # asynchronous point before a send.
             await self._get(remote)
+            return True
         return False
 
     async def determine_remote(self, message):

--- a/aiocoap/transports/tcp.py
+++ b/aiocoap/transports/tcp.py
@@ -171,7 +171,7 @@ class TcpConnection(
         # * send event through pool so it can propagate the error to all
         #   requests on the same remote
         # * mark the address as erroneous so it won't be recognized by
-        #   fill_or_recognize_remote
+        #   determine_remote
 
         self._ctx._dispatch_error(self, exc)
 
@@ -342,15 +342,12 @@ class TCPServer(_TCPPooling, interfaces.TokenInterface):
 
     # implementing TokenInterface
 
-    async def fill_or_recognize_remote(self, message):
-        if (
-            message.remote is not None
-            and isinstance(message.remote, TcpConnection)
-            and message.remote._ctx is self
-        ):
-            return True
+    async def recognize_remote(self, message):
+        return isinstance(message.remote, TcpConnection) and message.remote._ctx is self
 
-        return False
+    async def determine_remote(self, message):
+        # We're a server at the transport level
+        return None
 
     async def shutdown(self):
         self.log.debug("Shutting down server %r", self)
@@ -450,24 +447,17 @@ class TCPClient(_TCPPooling, interfaces.TokenInterface):
 
     # implementing TokenInterface
 
-    async def fill_or_recognize_remote(self, message):
-        if (
-            message.remote is not None
-            and isinstance(message.remote, TcpConnection)
-            and message.remote._ctx is self
-        ):
-            return True
+    async def recognize_remote(self, message):
+        return isinstance(message.remote, TcpConnection) and message.remote._ctx is self
 
+    async def determine_remote(self, message):
         if message.requested_scheme == self._scheme:
             # FIXME: This could pool outgoing connections.
             # (Checking if an incoming connection is a pool candidate is
             # probably overkill because even if a URI can be constructed from a
             # ephemeral client port, nobody but us can use it, and we can just
             # set .remote).
-            message.remote = await self._spawn_protocol(message)
-            return True
-
-        return False
+            return await self._spawn_protocol(message)
 
     async def shutdown(self):
         self.log.debug("Shutting down any outgoing connections on on %r", self)

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -305,6 +305,10 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
             "_remote_being_sent_to", default=None
         )
 
+    def __repr__(self):
+        socket = self.transport.get_extra_info("socket")
+        return f"<{type(self).__name__} at {id(self):#x} bound to {socket.getsockname() if socket else '(nothing)'}>"
+
     def _local_port(self):
         # FIXME: either raise an error if this is 0, or send a message to self
         # to force the OS to decide on a port. Right now, this reports wrong

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -307,7 +307,15 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
 
     def __repr__(self):
         socket = self.transport.get_extra_info("socket")
-        return f"<{type(self).__name__} at {id(self):#x} bound to {socket.getsockname() if socket else '(nothing)'}>"
+        if socket is not None:
+            try:
+                sockname = socket.getsockname()
+            except OSError as e:
+                # This has only ever failed on Windows
+                sockname = f"(getsockname failed: {e})"
+        else:
+            sockname = "(no socket in extra info)"
+        return f"<{type(self).__name__} at {id(self):#x} bound to {sockname}>"
 
     def _local_port(self):
         # FIXME: either raise an error if this is 0, or send a message to self

--- a/aiocoap/transports/udp6.py
+++ b/aiocoap/transports/udp6.py
@@ -401,11 +401,22 @@ class MessageInterfaceUDP6(RecvmsgDatagramProtocol, interfaces.MessageInterface)
                     sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
 
                     try:
-                        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_RECVPKTINFO, 1)
+                        # On Windows they call it different, but
+                        # <https://learn.microsoft.com/en-us/windows/win32/winsock/ipv6-pktinfo>
+                        # describes what it does, and that's the same as
+                        # RECVPKTINFO everywhere else.
+                        pktinfo_option = (
+                            socket.IPV6_RECVPKTINFO
+                            if hasattr(socket, "IPV6_RECVPKTINFO")
+                            else socket.IPV6_PKTINFO
+                        )
                     except NameError:
                         raise RuntimeError(
                             "RFC3542 PKTINFO flags are unavailable, unable to create a udp6 transport."
                         )
+
+                    sock.setsockopt(socket.IPPROTO_IPV6, pktinfo_option, 1)
+
                     if socknumbers.HAS_RECVERR:
                         sock.setsockopt(
                             socket.IPPROTO_IPV6, socknumbers.IPV6_RECVERR, 1

--- a/aiocoap/transports/ws.py
+++ b/aiocoap/transports/ws.py
@@ -402,29 +402,25 @@ class WSPool(interfaces.TokenInterface):
 
     # Implementation of TokenInterface
 
-    async def fill_or_recognize_remote(self, message):
-        if isinstance(message.remote, WSRemote) and message.remote._pool() is self:
-            return True
+    async def recognize_remote(self, message):
+        return isinstance(message.remote, WSRemote) and message.remote._pool() is self
 
+    async def determine_remote(self, message):
         if message.requested_scheme in ("coap+ws", "coaps+ws"):
             key = PoolKey(message.requested_scheme, message.remote.hostinfo)
 
             if key in self._pool:
-                message.remote = self._pool[key]
                 # It would have handled the ConnectionClosed on recv and
                 # removed itself if it was not live.
-                return True
+                return self._pool[key]
 
             if key not in self._outgoing_starting:
                 self._connect(key)
             # It's a bit unorthodox to wait for an (at least partially)
-            # established connection in fill_or_recognize_remote, but it's
+            # established connection in determine_remote, but it's
             # not completely off off either, and it makes it way easier to
             # not have partially initialized remotes around
-            message.remote = await self._outgoing_starting[key]
-            return True
-
-        return False
+            return await self._outgoing_starting[key]
 
     def send_message(self, message, messageerror_monitor):
         # Ignoring messageerror_monitor: CoAP over reliable transports has no

--- a/tests/test_blockwise.py
+++ b/tests/test_blockwise.py
@@ -15,6 +15,7 @@ from .test_server import (
     WithTestServer,
     WithClient,
     no_warnings,
+    slow_empty_ack,
     BigResource,
     BasicTestingSite,
 )
@@ -74,6 +75,10 @@ class TestBlockwise(WithChunkyTestServer, WithClient):
         )
 
     @no_warnings
+    # because we're counting responses, and on slow loaded systems a response
+    # might all of a sudden take 0.2s -- it's unlikely, but we're counting 80
+    # of them.
+    @slow_empty_ack()
     async def test_client_hints(self):
         """Test whether a handle_blockwise=True request takes a block2 option
         set in it as a hint to start requesting with a low size right away

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -72,7 +72,7 @@ class TestClientWithSetHost(WithTestServer, WithClient):
         resp = self.client.request(request).response
         try:
             # give the request some time to finish getaddrinfo
-            result = await asyncio.as_completed([resp], timeout=0.1).__next__()
+            result = await asyncio.as_completed([resp], timeout=0.5).__next__()
         except aiocoap.error.NetworkError as e:
             # This is a bit stricter than what the API indicates, but hey, we
             # can still relax the tests.

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -260,8 +260,8 @@ class TestCommandlineClient(WithTestServer):
         )
         # Or similar; what matters is that the URI is properly recomposed
         self.assertEqual(
-            b"Location options indicate new resource: /create/here/?this=this&that=that\n",
-            diagnostic_post,
+            b"Location options indicate new resource: /create/here/?this=this&that=that",
+            diagnostic_post.strip(),
         )
 
     @no_warnings

--- a/tests/test_multitransport_rolereversal.py
+++ b/tests/test_multitransport_rolereversal.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Christian Amsüss and the aiocoap contributors
+#
+# SPDX-License-Identifier: MIT
+
+import unittest
+
+import aiocoap
+from aiocoap import resource
+
+from .test_server import WhoAmI
+
+
+class RoleReverseAndQueryWhoAmI(resource.Resource):
+    context: aiocoap.Context
+
+    async def render_post(self, request):
+        counter_request = aiocoap.Message(code=aiocoap.GET, uri_path=["whoami"])
+        counter_request.remote = request.remote
+        response = await self.context.request(counter_request).response_raising
+        # Maybe we should raise a warning but ignore this...
+        response.direction = aiocoap.message.Direction.OUTGOING
+        # ... like we do with those (just clearing them for the warnings)
+        response.mid = None
+        response.token = None
+        return response
+
+
+class TestMultitransportRolereversal(unittest.IsolatedAsyncioTestCase):
+    """A test family for whether even when multiple transports are active, role
+    reversal works as it should."""
+
+    async def test_udp6_multiport(self):
+        """Let a client connect to a udp6 multiply bound server, and verify
+        that role reversal comes from the right place.
+
+        This is a bit of a funny test because it enforces UDP6 on one side
+        while using the defaults on the other."""
+
+        checkme = RoleReverseAndQueryWhoAmI()
+        serversite = resource.Site()
+        serversite.add_resource(["checkme"], checkme)
+
+        serverctx = await aiocoap.Context.create_server_context(
+            serversite,
+            transports={
+                "udp6": {
+                    "bind": ["[::]:5001", "[::]:5002"],
+                }
+            },
+        )
+        checkme.context = serverctx
+
+        clientsite = resource.Site()
+        clientsite.add_resource(["whoami"], WhoAmI())
+        clientctx = await aiocoap.Context.create_client_context()
+        clientctx.serversite = clientsite
+
+        response = await clientctx.request(
+            aiocoap.Message(code=aiocoap.POST, uri="coap://localhost:5002/checkme")
+        ).response_raising
+        self.assertRegex(response.payload.decode("utf8"), ":5002")


### PR DESCRIPTION
In the latest update to udp6 I claimed that RECVPKTINFO was widely supported by now, so I thought I'd just run tests on Windows to see whether this even applies there. (Works on the widesprad UNIXes, including Android and MacOS in recent Python versions).

Turned out that while IPV6_RECVPKTINFO is still not there yet, according to https://learn.microsoft.com/en-us/windows/win32/winsock/ipv6-pktinfo they just use a different name for the same thing, so giving it a try.

(Running on GitHub as they're offering Windows runners; I get that Codeberg can't do this, but providing proprietary OS runners is probably the one thing GH is good for now still).